### PR TITLE
On push

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,35 @@ policies:
   merged has protections enabled and requires signed commits. Additionally, all
   commits on the branch and not on the target branch must be signed. Not
   applicable to forked source branches.
+* `branch_protection`: That the branch containing the commits has protections
+  enabled and requires signed commits. Additionally, all commits on the branch
+  and not on the default branch must be signed and the commit the job is running
+  on must be signed.
 * `collaborators`: Check that all outside collaborators of the project have at
   most `read` permissions.
 * `execute_job`: That a maintainer or above has left the comment
   `/canonical/self-hosted-runners/run-workflows <commit SHA>` approving a
   workflow run for a specific commit SHA. Only applicable to forked source
   branches.
-* `all_`: All of the above are checked.
+* `pull_request`: Runs `target_branch_protection`, `source_branch_protection`,
+  `collaborators` and `execute_job`.
+* `workflow_dispatch`: Runs `branch_protection` and `collaborators`.
+* `push`: Runs `branch_protection` and `collaborators`.
 
 These policies are designed for workflow runs in the context of a pull request.
+
+## Customizing Enabled Policies
+
+Each of `pull_request`, `workflow_dispatch` and `push` accept a
+`policy_document` argument which can be used to change which policies are
+enabled. If supplied, it should be a dictionary that complies with the
+[policy JSON schema](repo_policy_compliance/policy_schema.yaml)
+
+## Flask Blueprint
+
+The functions are made available via a
+[flask blueprint](repo_policy_compliance/blueprint.py). This is designed to run
+in a single thread for simplicity.
 
 ## Running the Tests
 

--- a/repo_policy_compliance/__init__.py
+++ b/repo_policy_compliance/__init__.py
@@ -3,18 +3,16 @@
 
 """Library for checking that GitHub repos comply with policy."""
 
-import logging
-import sys
 from enum import Enum
 from types import MappingProxyType
-from typing import Callable, NamedTuple, ParamSpec, TypeVar, cast
+from typing import NamedTuple, cast
 
 from github import Github
 from github.Branch import Branch
 from github.Repository import Repository
 from pydantic import BaseModel, Field
 
-from . import policy
+from . import log, policy
 from .comment import remove_quote_lines
 from .github_client import get_collaborators
 from .github_client import inject as inject_github_client
@@ -61,58 +59,7 @@ class Report(NamedTuple):
     reason: str | None
 
 
-P = ParamSpec("P")
-R = TypeVar("R")
-
-
-def log_check(func: Callable[P, R]) -> Callable[P, R]:
-    """Log before check and result of check.
-
-    Args:
-        func: The function that executes a check.
-
-    Returns:
-        The function where the check is logged before it starts and the results are logged.
-    """
-    check_name = func.__name__
-
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        """Replace function.
-
-        Args:
-            args: The positional arguments passed to the method
-            kwargs: The keywords arguments passed to the method
-
-        Returns:
-            The return value after calling the wrapped function.
-        """
-        logging.info("start check '%s'", check_name)
-        result = func(*args, **kwargs)
-        logging.info("check '%s' finished, result: %s", check_name, result)
-        return result
-
-    return wrapper
-
-
-def _setup_logging() -> None:
-    """Initialise logging for check execution."""
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(logging.DEBUG)
-    formatter = logging.Formatter("%(asctime)s - %(message)s")
-    handler.setFormatter(formatter)
-
-    # Setup local logging
-    logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(handler)
-
-    # Setup urllib3 logging
-    urllib3_logger = logging.getLogger("urllib3")
-    urllib3_logger.setLevel(logging.DEBUG)
-    urllib3_logger.addHandler(handler)
-
-
-_setup_logging()
+log.setup()
 
 
 def _get_branch(github_client: Github, repository_name: str, branch_name: str) -> Branch:
@@ -130,7 +77,7 @@ def _get_branch(github_client: Github, repository_name: str, branch_name: str) -
     return repository.get_branch(branch_name)
 
 
-@log_check
+@log.check
 def _check_branch_protected(branch: Branch) -> Report:
     """Check that the branch has protections enabled.
 
@@ -148,7 +95,7 @@ def _check_branch_protected(branch: Branch) -> Report:
     return Report(result=Result.PASS, reason=None)
 
 
-@log_check
+@log.check
 def _check_signed_commits_required(branch: Branch) -> Report:
     """Check that the branch requires signed commits.
 
@@ -166,7 +113,7 @@ def _check_signed_commits_required(branch: Branch) -> Report:
     return Report(result=Result.PASS, reason=None)
 
 
-@log_check
+@log.check
 def _check_unique_commits_signed(
     branch_name: str, other_branch_name: str, repository: Repository
 ) -> Report:
@@ -230,7 +177,7 @@ class PullRequestInput(BaseModel):
     commit_sha: str = Field(min_length=1)
 
 
-@log_check
+@log.check
 def pull_request(
     input_: PullRequestInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL
 ) -> Report:
@@ -336,7 +283,7 @@ class BranchInput(BaseModel):
 WorkflowDispatchInput = BranchInput
 
 
-@log_check
+@log.check
 def workflow_dispatch(
     input_: WorkflowDispatchInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL
 ) -> Report:
@@ -394,7 +341,7 @@ def workflow_dispatch(
 PushInput = BranchInput
 
 
-@log_check
+@log.check
 def push(input_: PushInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL) -> Report:
     """Run all the checks for on push jobs.
 
@@ -448,7 +395,7 @@ def push(input_: PushInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL)
 
 
 @inject_github_client
-@log_check
+@log.check
 def target_branch_protection(
     github_client: Github, repository_name: str, branch_name: str
 ) -> Report:
@@ -502,7 +449,7 @@ def target_branch_protection(
 
 
 @inject_github_client
-@log_check
+@log.check
 def source_branch_protection(
     github_client: Github,
     repository_name: str,
@@ -553,7 +500,7 @@ def source_branch_protection(
 
 
 @inject_github_client
-@log_check
+@log.check
 def branch_protection(
     github_client: Github,
     repository_name: str,
@@ -608,7 +555,7 @@ def branch_protection(
 
 
 @inject_github_client
-@log_check
+@log.check
 def collaborators(github_client: Github, repository_name: str) -> Report:
     """Check that no outside contributors have higher access than read.
 
@@ -644,7 +591,7 @@ def collaborators(github_client: Github, repository_name: str) -> Report:
 
 
 @inject_github_client
-@log_check
+@log.check
 def execute_job(
     github_client: Github,
     repository_name: str,

--- a/repo_policy_compliance/__init__.py
+++ b/repo_policy_compliance/__init__.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field
 
 from . import log, policy
 from .comment import remove_quote_lines
-from .github_client import get_collaborators
+from .github_client import get_branch, get_collaborators
 from .github_client import inject as inject_github_client
 
 BYPASS_ALLOWANCES_KEY = "bypass_pull_request_allowances"
@@ -60,21 +60,6 @@ class Report(NamedTuple):
 
 
 log.setup()
-
-
-def _get_branch(github_client: Github, repository_name: str, branch_name: str) -> Branch:
-    """Get the branch for the check.
-
-    Args:
-        github_client: The client to be used for GitHub API interactions.
-        repository_name: The name of the repository to run the check on.
-        branch_name: The name of the branch to check.
-
-    Returns:
-        The requested branch.
-    """
-    repository = github_client.get_repo(repository_name)
-    return repository.get_branch(branch_name)
 
 
 @log.check
@@ -409,7 +394,7 @@ def target_branch_protection(
     Returns:
         Whether the branch has appropriate protections.
     """
-    branch = _get_branch(
+    branch = get_branch(
         github_client=github_client, repository_name=repository_name, branch_name=branch_name
     )
 
@@ -474,7 +459,7 @@ def source_branch_protection(
     if source_repository_name != repository_name:
         return Report(result=Result.PASS, reason=None)
 
-    branch = _get_branch(
+    branch = get_branch(
         github_client=github_client, repository_name=repository_name, branch_name=branch_name
     )
 
@@ -518,7 +503,7 @@ def branch_protection(
     Returns:
         Whether the branch has appropriate protections.
     """
-    branch = _get_branch(
+    branch = get_branch(
         github_client=github_client, repository_name=repository_name, branch_name=branch_name
     )
 

--- a/repo_policy_compliance/__init__.py
+++ b/repo_policy_compliance/__init__.py
@@ -5,133 +5,11 @@
 
 from enum import Enum
 from types import MappingProxyType
-from typing import NamedTuple, cast
+from typing import cast
 
-from github import Github
-from github.Branch import Branch
-from github.Repository import Repository
 from pydantic import BaseModel, Field
 
-from . import log, policy
-from .comment import remove_quote_lines
-from .github_client import get_branch, get_collaborators
-from .github_client import inject as inject_github_client
-
-BYPASS_ALLOWANCES_KEY = "bypass_pull_request_allowances"
-AUTHORIZATION_STRING_PREFIX = "/canonical/self-hosted-runners/run-workflows"
-EXECUTE_JOB_MESSAGE = (
-    "execution not authorized, a comment from a maintainer or above on the repository approving "
-    "the workflow was not found on a PR from a fork, the comment should include the string "
-    f"'{AUTHORIZATION_STRING_PREFIX} <commit SHA>' where the commit SHA is the SHA of the latest "
-    "commit on the branch"
-)
-FAILURE_MESSAGE = (
-    "\n"
-    "This job has failed to pass a repository policy compliance check as defined in "
-    "https://github.com/canonical/repo-policy-compliance. The specific failure is listed "
-    "below. Please update the settings on this project to fix the relevant policy."
-    "\n"
-)
-
-
-class Result(str, Enum):
-    """The result of a check.
-
-    Attrs:
-        PASS: The check passed.
-        FAIL: The check failed.
-    """
-
-    # Bandit thinks pass is for password
-    PASS = "pass"  # nosec
-    FAIL = "fail"
-
-
-class Report(NamedTuple):
-    """Reports the result of a check.
-
-    Attrs:
-        result: The check result.
-        reason: If the check failed, the reason why it failed.
-    """
-
-    result: Result
-    reason: str | None
-
-
-log.setup()
-
-
-@log.check
-def _check_branch_protected(branch: Branch) -> Report:
-    """Check that the branch has protections enabled.
-
-    Args:
-        branch: The branch to check.
-
-    Returns:
-        Whether the branch has protections enabled.
-    """
-    if not branch.protected:
-        return Report(
-            result=Result.FAIL,
-            reason=(f"{FAILURE_MESSAGE}branch protection not enabled, {branch.name=!r}"),
-        )
-    return Report(result=Result.PASS, reason=None)
-
-
-@log.check
-def _check_signed_commits_required(branch: Branch) -> Report:
-    """Check that the branch requires signed commits.
-
-    Args:
-        branch: The branch to check.
-
-    Returns:
-        Whether the branch requires signed commits.
-    """
-    if not branch.get_required_signatures():
-        return Report(
-            result=Result.FAIL,
-            reason=(f"{FAILURE_MESSAGE}signed commits not required, {branch.name=!r}"),
-        )
-    return Report(result=Result.PASS, reason=None)
-
-
-@log.check
-def _check_unique_commits_signed(
-    branch_name: str, other_branch_name: str, repository: Repository
-) -> Report:
-    """Check that the commits unique to a branch are signed.
-
-    Args:
-        branch_name: The name of the branch to check.
-        other_branch_name: The name of the branch which will be used to exclude commits.
-        repository: The repository the branches are on.
-
-    Returns:
-        Whether the unique commits on the branch are signed.
-    """
-    other_branch_commit_shas = {
-        commit.sha for commit in repository.get_commits(sha=other_branch_name)
-    }
-    branch_commits = repository.get_commits(sha=branch_name)
-    unsigned_unique_branch_commits = (
-        commit
-        for commit in branch_commits
-        if commit.sha not in other_branch_commit_shas
-        and not commit.commit.raw_data["verification"]["verified"]
-    )
-    if first_unsigned_commit := next(unsigned_unique_branch_commits, None):
-        return Report(
-            result=Result.FAIL,
-            reason=(
-                f"{FAILURE_MESSAGE}"
-                f"commit is not signed, {branch_name=!r}, {first_unsigned_commit.sha=!r}"
-            ),
-        )
-
-    return Report(result=Result.PASS, reason=None)
+from . import check, log, policy
 
 
 class UsedPolicy(Enum):
@@ -162,10 +40,10 @@ class PullRequestInput(BaseModel):
     commit_sha: str = Field(min_length=1)
 
 
-@log.check
+@log.func
 def pull_request(
     input_: PullRequestInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL
-) -> Report:
+) -> check.Report:
     """Run all the checks for pull request jobs.
 
     Args:
@@ -181,7 +59,7 @@ def pull_request(
         # Guaranteed to be a dict due to initial if
         policy_document = cast(dict, policy_document)
         if not (policy_report := policy.check(document=policy_document)).result:
-            return Report(result=Result.FAIL, reason=policy_report.reason)
+            return check.Report(result=check.Result.FAIL, reason=policy_report.reason)
         used_policy_document = MappingProxyType(policy_document)
 
     # The github_client argument is injected, disabling missing arguments check for this function
@@ -193,11 +71,11 @@ def pull_request(
             policy_document=used_policy_document,
         )
         and (
-            target_branch_report := target_branch_protection(
+            target_branch_report := check.target_branch_protection(
                 repository_name=input_.repository_name, branch_name=input_.target_branch_name
             )
         ).result
-        == Result.FAIL
+        == check.Result.FAIL
     ):
         return target_branch_report
 
@@ -208,14 +86,14 @@ def pull_request(
             policy_document=used_policy_document,
         )
         and (
-            source_branch_report := source_branch_protection(
+            source_branch_report := check.source_branch_protection(
                 repository_name=input_.repository_name,
                 source_repository_name=input_.source_repository_name,
                 branch_name=input_.source_branch_name,
                 target_branch_name=input_.target_branch_name,
             )
         ).result
-        == Result.FAIL
+        == check.Result.FAIL
     ):
         return source_branch_report
 
@@ -225,8 +103,10 @@ def pull_request(
             name=policy.PullRequestProperty.COLLABORATORS,
             policy_document=used_policy_document,
         )
-        and (collaborators_report := collaborators(repository_name=input_.repository_name)).result
-        == Result.FAIL
+        and (
+            collaborators_report := check.collaborators(repository_name=input_.repository_name)
+        ).result
+        == check.Result.FAIL
     ):
         return collaborators_report
 
@@ -237,18 +117,18 @@ def pull_request(
             policy_document=used_policy_document,
         )
         and (
-            execute_job_report := execute_job(
+            execute_job_report := check.execute_job(
                 repository_name=input_.repository_name,
                 source_repository_name=input_.source_repository_name,
                 branch_name=input_.source_branch_name,
                 commit_sha=input_.commit_sha,
             )
         ).result
-        == Result.FAIL
+        == check.Result.FAIL
     ):
         return execute_job_report
 
-    return Report(result=Result.PASS, reason=None)
+    return check.Report(result=check.Result.PASS, reason=None)
 
 
 class BranchInput(BaseModel):
@@ -268,10 +148,10 @@ class BranchInput(BaseModel):
 WorkflowDispatchInput = BranchInput
 
 
-@log.check
+@log.func
 def workflow_dispatch(
     input_: WorkflowDispatchInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL
-) -> Report:
+) -> check.Report:
     """Run all the checks for workflow dispatch jobs.
 
     Args:
@@ -287,7 +167,7 @@ def workflow_dispatch(
         # Guaranteed to be a dict due to initial if
         policy_document = cast(dict, policy_document)
         if not (policy_report := policy.check(document=policy_document)).result:
-            return Report(result=Result.FAIL, reason=policy_report.reason)
+            return check.Report(result=check.Result.FAIL, reason=policy_report.reason)
         used_policy_document = MappingProxyType(policy_document)
 
     # The github_client argument is injected, disabling missing arguments check for this function
@@ -299,13 +179,13 @@ def workflow_dispatch(
             policy_document=used_policy_document,
         )
         and (
-            branch_report := branch_protection(
+            branch_report := check.branch_protection(
                 repository_name=input_.repository_name,
                 branch_name=input_.branch_name,
                 commit_sha=input_.commit_sha,
             )
         ).result
-        == Result.FAIL
+        == check.Result.FAIL
     ):
         return branch_report
 
@@ -315,19 +195,21 @@ def workflow_dispatch(
             name=policy.WorkflowDispatchProperty.COLLABORATORS,
             policy_document=used_policy_document,
         )
-        and (collaborators_report := collaborators(repository_name=input_.repository_name)).result
-        == Result.FAIL
+        and (
+            collaborators_report := check.collaborators(repository_name=input_.repository_name)
+        ).result
+        == check.Result.FAIL
     ):
         return collaborators_report
 
-    return Report(result=Result.PASS, reason=None)
+    return check.Report(result=check.Result.PASS, reason=None)
 
 
 PushInput = BranchInput
 
 
-@log.check
-def push(input_: PushInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL) -> Report:
+@log.func
+def push(input_: PushInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL) -> check.Report:
     """Run all the checks for on push jobs.
 
     Args:
@@ -343,7 +225,7 @@ def push(input_: PushInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL)
         # Guaranteed to be a dict due to initial if
         policy_document = cast(dict, policy_document)
         if not (policy_report := policy.check(document=policy_document)).result:
-            return Report(result=Result.FAIL, reason=policy_report.reason)
+            return check.Report(result=check.Result.FAIL, reason=policy_report.reason)
         used_policy_document = MappingProxyType(policy_document)
 
     # The github_client argument is injected, disabling missing arguments check for this function
@@ -355,13 +237,13 @@ def push(input_: PushInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL)
             policy_document=used_policy_document,
         )
         and (
-            branch_report := branch_protection(
+            branch_report := check.branch_protection(
                 repository_name=input_.repository_name,
                 branch_name=input_.branch_name,
                 commit_sha=input_.commit_sha,
             )
         ).result
-        == Result.FAIL
+        == check.Result.FAIL
     ):
         return branch_report
 
@@ -371,287 +253,11 @@ def push(input_: PushInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL)
             name=policy.PushProperty.COLLABORATORS,
             policy_document=used_policy_document,
         )
-        and (collaborators_report := collaborators(repository_name=input_.repository_name)).result
-        == Result.FAIL
+        and (
+            collaborators_report := check.collaborators(repository_name=input_.repository_name)
+        ).result
+        == check.Result.FAIL
     ):
         return collaborators_report
 
-    return Report(result=Result.PASS, reason=None)
-
-
-@inject_github_client
-@log.check
-def target_branch_protection(
-    github_client: Github, repository_name: str, branch_name: str
-) -> Report:
-    """Check that the target branch has appropriate protections.
-
-    Args:
-        github_client: The client to be used for GitHub API interactions.
-        repository_name: The name of the repository to run the check on.
-        branch_name: The name of the branch to check.
-
-    Returns:
-        Whether the branch has appropriate protections.
-    """
-    branch = get_branch(
-        github_client=github_client, repository_name=repository_name, branch_name=branch_name
-    )
-
-    if (protected_report := _check_branch_protected(branch=branch)).result == Result.FAIL:
-        return protected_report
-
-    protection = branch.get_protection()
-
-    pull_request_reviews = protection.required_pull_request_reviews
-    if not pull_request_reviews.require_code_owner_reviews:
-        return Report(
-            result=Result.FAIL,
-            reason=(
-                f"{FAILURE_MESSAGE}"
-                f"codeowner pull request reviews are not required, {branch_name=!r}"
-            ),
-        )
-    if not pull_request_reviews.dismiss_stale_reviews:
-        return Report(
-            result=Result.FAIL,
-            reason=(f"{FAILURE_MESSAGE}stale reviews are not dismissed, {branch_name=!r}"),
-        )
-    # Check for bypass allowances
-    bypass_allowances = pull_request_reviews.raw_data.get(BYPASS_ALLOWANCES_KEY, {})
-    if any(bypass_allowances.get(key, []) for key in ("users", "teams", "apps")):
-        return Report(
-            result=Result.FAIL,
-            reason=(f"{FAILURE_MESSAGE}pull request reviews can be bypassed, {branch_name=!r}"),
-        )
-
-    if (
-        signed_commits_report := _check_signed_commits_required(branch=branch)
-    ).result == Result.FAIL:
-        return signed_commits_report
-
-    return Report(result=Result.PASS, reason=None)
-
-
-@inject_github_client
-@log.check
-def source_branch_protection(
-    github_client: Github,
-    repository_name: str,
-    source_repository_name: str,
-    branch_name: str,
-    target_branch_name: str,
-) -> Report:
-    """Check that the source branch has appropriate protections.
-
-    Args:
-        github_client: The client to be used for GitHub API interactions.
-        repository_name: The name of the repository to run the check on.
-        source_repository_name: The name of the repository that contains the source branch.
-        branch_name: The name of the branch to check.
-        target_branch_name: The name of the branch that the source branch is proposed to be merged
-            into.
-
-    Returns:
-        Whether the branch has appropriate protections.
-    """
-    # Check for fork
-    if source_repository_name != repository_name:
-        return Report(result=Result.PASS, reason=None)
-
-    branch = get_branch(
-        github_client=github_client, repository_name=repository_name, branch_name=branch_name
-    )
-
-    if (protected_report := _check_branch_protected(branch=branch)).result == Result.FAIL:
-        return protected_report
-
-    if (
-        signed_commits_report := _check_signed_commits_required(branch=branch)
-    ).result == Result.FAIL:
-        return signed_commits_report
-
-    repository = github_client.get_repo(repository_name)
-    if (
-        unique_commits_signed_report := _check_unique_commits_signed(
-            branch_name=branch_name,
-            other_branch_name=target_branch_name,
-            repository=repository,
-        )
-    ).result == Result.FAIL:
-        return unique_commits_signed_report
-
-    return Report(result=Result.PASS, reason=None)
-
-
-@inject_github_client
-@log.check
-def branch_protection(
-    github_client: Github,
-    repository_name: str,
-    branch_name: str,
-    commit_sha: str,
-) -> Report:
-    """Check that the branch has appropriate protections.
-
-    Args:
-        github_client: The client to be used for GitHub API interactions.
-        repository_name: The name of the repository to run the check on.
-        branch_name: The name of the branch to check.
-        commit_sha: The SHA of the commit that the workflow run is on.
-
-    Returns:
-        Whether the branch has appropriate protections.
-    """
-    branch = get_branch(
-        github_client=github_client, repository_name=repository_name, branch_name=branch_name
-    )
-
-    if (protected_report := _check_branch_protected(branch=branch)).result == Result.FAIL:
-        return protected_report
-
-    if (
-        signed_commits_report := _check_signed_commits_required(branch=branch)
-    ).result == Result.FAIL:
-        return signed_commits_report
-
-    repository = github_client.get_repo(repository_name)
-    if (
-        unique_commits_signed_report := _check_unique_commits_signed(
-            branch_name=branch_name,
-            other_branch_name=repository.default_branch,
-            repository=repository,
-        )
-    ).result == Result.FAIL:
-        return unique_commits_signed_report
-
-    # Check that the commit the job is running on is signed
-    commit = repository.get_commit(sha=commit_sha)
-    if not commit.commit.raw_data["verification"]["verified"]:
-        return Report(
-            result=Result.FAIL,
-            reason=(
-                f"{FAILURE_MESSAGE}"
-                f"commit the job is running on is not signed, {branch_name=!r}, {commit_sha=!r}"
-            ),
-        )
-
-    return Report(result=Result.PASS, reason=None)
-
-
-@inject_github_client
-@log.check
-def collaborators(github_client: Github, repository_name: str) -> Report:
-    """Check that no outside contributors have higher access than read.
-
-    Args:
-        github_client: The client to be used for GitHub API interactions.
-        repository_name: The name of the repository to run the check on.
-
-    Returns:
-        Whether there are any outside collaborators with higher than read permissions.
-    """
-    repository = github_client.get_repo(repository_name)
-    outside_collaborators = get_collaborators(
-        repository=repository, permission="triage", affiliation="outside"
-    )
-
-    higher_permission_logins = tuple(
-        collaborator["login"]
-        for collaborator in outside_collaborators
-        if collaborator["role_name"] != "read"
-    )
-
-    if higher_permission_logins:
-        return Report(
-            result=Result.FAIL,
-            reason=(
-                f"{FAILURE_MESSAGE}"
-                "the repository includes outside collaborators with higher permissions than read,"
-                f"{higher_permission_logins=!r}"
-            ),
-        )
-
-    return Report(result=Result.PASS, reason=None)
-
-
-@inject_github_client
-@log.check
-def execute_job(
-    github_client: Github,
-    repository_name: str,
-    source_repository_name: str,
-    branch_name: str,
-    commit_sha: str,
-) -> Report:
-    """Check that the execution of the workflow for a SHA has been granted for a PR from a fork.
-
-    Args:
-        github_client: The client to be used for GitHub API interactions.
-        repository_name: The name of the repository to run the check on.
-        source_repository_name: The name of the repository that contains the source branch.
-        branch_name: The name of the branch that has the PR.
-        commit_sha: The SHA of the commit that the workflow run is on.
-
-    Returns:
-        Whether the workflow run has been approved for the commit SHA.
-    """
-    # Not from a forked repository
-    if repository_name == source_repository_name:
-        return Report(result=Result.PASS, reason=None)
-
-    # Retrieve PR for the branch
-    repository = github_client.get_repo(repository_name)
-    pulls = repository.get_pulls(state="open")
-    pull_for_branch = next((pull for pull in pulls if pull.head.ref == branch_name), None)
-    if not pull_for_branch:
-        return Report(
-            result=Result.FAIL,
-            reason=(f"{FAILURE_MESSAGE}no open pull requests for branch {branch_name}"),
-        )
-
-    # Retrieve comments on the PR
-    comments = pull_for_branch.get_issue_comments()
-    if not comments.totalCount:
-        return Report(
-            result=Result.FAIL,
-            reason=(
-                f"{FAILURE_MESSAGE}"
-                f"no comment found on PR - {EXECUTE_JOB_MESSAGE}, {branch_name=}, {commit_sha=} "
-                f"{pull_for_branch.number=}"
-            ),
-        )
-
-    # Check for authroization comment
-    authorization_string = f"{AUTHORIZATION_STRING_PREFIX} {commit_sha}"
-    authorization_comments = tuple(
-        comment for comment in comments if authorization_string in remove_quote_lines(comment.body)
-    )
-    if not authorization_comments:
-        return Report(
-            result=Result.FAIL,
-            reason=(
-                f"{FAILURE_MESSAGE}"
-                f"authorization comment not found on PR, expected: {authorization_string} - "
-                f"{EXECUTE_JOB_MESSAGE}, {branch_name=}, {commit_sha=}, {pull_for_branch.number=}"
-            ),
-        )
-
-    # Check that the commenter has maintain or above permissions
-    maintain_logins = {
-        collaborator["login"]
-        for collaborator in get_collaborators(
-            repository=repository, permission="maintain", affiliation="all"
-        )
-    }
-    if not any(comment.user.login in maintain_logins for comment in authorization_comments):
-        return Report(
-            result=Result.FAIL,
-            reason=(
-                f"{FAILURE_MESSAGE}"
-                "authorization comment from a user that is not a maintainer or above - "
-                f"{EXECUTE_JOB_MESSAGE}, {branch_name=}, {commit_sha=}, {pull_for_branch.number=}"
-            ),
-        )
-
-    return Report(result=Result.PASS, reason=None)
+    return check.Report(result=check.Result.PASS, reason=None)

--- a/repo_policy_compliance/__init__.py
+++ b/repo_policy_compliance/__init__.py
@@ -40,7 +40,7 @@ class PullRequestInput(BaseModel):
     commit_sha: str = Field(min_length=1)
 
 
-@log.func
+@log.call
 def pull_request(
     input_: PullRequestInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL
 ) -> check.Report:
@@ -148,7 +148,7 @@ class BranchInput(BaseModel):
 WorkflowDispatchInput = BranchInput
 
 
-@log.func
+@log.call
 def workflow_dispatch(
     input_: WorkflowDispatchInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL
 ) -> check.Report:
@@ -208,7 +208,7 @@ def workflow_dispatch(
 PushInput = BranchInput
 
 
-@log.func
+@log.call
 def push(input_: PushInput, policy_document: dict | UsedPolicy = UsedPolicy.ALL) -> check.Report:
     """Run all the checks for on push jobs.
 

--- a/repo_policy_compliance/__init__.py
+++ b/repo_policy_compliance/__init__.py
@@ -320,7 +320,7 @@ def pull_request(
 
 
 class BranchInput(BaseModel):
-    """Input arguments for checks for jobs running on a branch.
+    """Input arguments to check jobs running on a branch.
 
     Attrs:
         repository_name: The name of the repository to run the check on.

--- a/repo_policy_compliance/blueprint.py
+++ b/repo_policy_compliance/blueprint.py
@@ -156,7 +156,7 @@ def policy_endpoint() -> Response:
         return Response(response=policy_report.reason, status=400)
 
     policy_document_path.write_text(json.dumps(data), encoding="utf-8")
-    return Response(status=http.HTTPStatus.NO_CONTENT[0])
+    return Response(status=http.HTTPStatus.NO_CONTENT)
 
 
 def _get_policy_document() -> dict | UsedPolicy:
@@ -189,9 +189,9 @@ def pull_request_check_run(body: PullRequestInput) -> Response:
     if (
         report := pull_request(input_=body, policy_document=policy_document)
     ).result == Result.FAIL:
-        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN[0])
+        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN)
 
-    return Response(status=http.HTTPStatus.NO_CONTENT[0])
+    return Response(status=http.HTTPStatus.NO_CONTENT)
 
 
 @repo_policy_compliance.route(WORKFLOW_DISPATCH_CHECK_RUN_ENDPOINT, methods=["POST"])
@@ -211,9 +211,9 @@ def workflow_dispatch_check_run(body: WorkflowDispatchInput) -> Response:
     if (
         report := workflow_dispatch(input_=body, policy_document=policy_document)
     ).result == Result.FAIL:
-        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN[0])
+        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN)
 
-    return Response(status=http.HTTPStatus.NO_CONTENT[0])
+    return Response(status=http.HTTPStatus.NO_CONTENT)
 
 
 @repo_policy_compliance.route(PUSH_CHECK_RUN_ENDPOINT, methods=["POST"])
@@ -231,9 +231,9 @@ def push_check_run(body: PushInput) -> Response:
     policy_document = _get_policy_document()
 
     if (report := push(input_=body, policy_document=policy_document)).result == Result.FAIL:
-        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN[0])
+        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN)
 
-    return Response(status=http.HTTPStatus.NO_CONTENT[0])
+    return Response(status=http.HTTPStatus.NO_CONTENT)
 
 
 @repo_policy_compliance.route(HEALTH_ENDPOINT, methods=["GET"])
@@ -247,11 +247,11 @@ def health() -> Response:
         client = github_client.get()
         client.get_repo("canonical/repo-policy-compliance")
     except exceptions.InputError as exc:
-        return Response(response=str(exc), status=http.HTTPStatus.INTERNAL_SERVER_ERROR[0])
+        return Response(response=str(exc), status=http.HTTPStatus.INTERNAL_SERVER_ERROR)
     except GithubException as exc:
         return Response(
             response=f"could not communicate with GitHub, {exc}",
-            status=http.HTTPStatus.INTERNAL_SERVER_ERROR[0],
+            status=http.HTTPStatus.INTERNAL_SERVER_ERROR,
         )
 
-    return Response(status=http.HTTPStatus.NO_CONTENT[0])
+    return Response(status=http.HTTPStatus.NO_CONTENT)

--- a/repo_policy_compliance/blueprint.py
+++ b/repo_policy_compliance/blueprint.py
@@ -27,7 +27,6 @@ from github import GithubException
 from . import (
     PullRequestInput,
     PushInput,
-    Result,
     UsedPolicy,
     WorkflowDispatchInput,
     exceptions,
@@ -37,6 +36,7 @@ from . import (
     push,
     workflow_dispatch,
 )
+from .check import Result
 
 repo_policy_compliance = Blueprint("repo_policy_compliance", __name__)
 auth = HTTPTokenAuth(scheme="Bearer")

--- a/repo_policy_compliance/blueprint.py
+++ b/repo_policy_compliance/blueprint.py
@@ -156,7 +156,7 @@ def policy_endpoint() -> Response:
         return Response(response=policy_report.reason, status=400)
 
     policy_document_path.write_text(json.dumps(data), encoding="utf-8")
-    return Response(status=http.HTTPStatus.NO_CONTENT)
+    return Response(status=http.HTTPStatus.NO_CONTENT[0])
 
 
 def _get_policy_document() -> dict | UsedPolicy:
@@ -189,9 +189,9 @@ def pull_request_check_run(body: PullRequestInput) -> Response:
     if (
         report := pull_request(input_=body, policy_document=policy_document)
     ).result == Result.FAIL:
-        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN)
+        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN[0])
 
-    return Response(status=http.HTTPStatus.NO_CONTENT)
+    return Response(status=http.HTTPStatus.NO_CONTENT[0])
 
 
 @repo_policy_compliance.route(WORKFLOW_DISPATCH_CHECK_RUN_ENDPOINT, methods=["POST"])
@@ -211,9 +211,9 @@ def workflow_dispatch_check_run(body: WorkflowDispatchInput) -> Response:
     if (
         report := workflow_dispatch(input_=body, policy_document=policy_document)
     ).result == Result.FAIL:
-        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN)
+        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN[0])
 
-    return Response(status=http.HTTPStatus.NO_CONTENT)
+    return Response(status=http.HTTPStatus.NO_CONTENT[0])
 
 
 @repo_policy_compliance.route(PUSH_CHECK_RUN_ENDPOINT, methods=["POST"])
@@ -231,9 +231,9 @@ def push_check_run(body: PushInput) -> Response:
     policy_document = _get_policy_document()
 
     if (report := push(input_=body, policy_document=policy_document)).result == Result.FAIL:
-        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN)
+        return Response(response=report.reason, status=http.HTTPStatus.FORBIDDEN[0])
 
-    return Response(status=http.HTTPStatus.NO_CONTENT)
+    return Response(status=http.HTTPStatus.NO_CONTENT[0])
 
 
 @repo_policy_compliance.route(HEALTH_ENDPOINT, methods=["GET"])
@@ -247,11 +247,11 @@ def health() -> Response:
         client = github_client.get()
         client.get_repo("canonical/repo-policy-compliance")
     except exceptions.InputError as exc:
-        return Response(response=str(exc), status=http.HTTPStatus.INTERNAL_SERVER_ERROR)
+        return Response(response=str(exc), status=http.HTTPStatus.INTERNAL_SERVER_ERROR[0])
     except GithubException as exc:
         return Response(
             response=f"could not communicate with GitHub, {exc}",
-            status=http.HTTPStatus.INTERNAL_SERVER_ERROR,
+            status=http.HTTPStatus.INTERNAL_SERVER_ERROR[0],
         )
 
-    return Response(status=http.HTTPStatus.NO_CONTENT)
+    return Response(status=http.HTTPStatus.NO_CONTENT[0])

--- a/repo_policy_compliance/blueprint.py
+++ b/repo_policy_compliance/blueprint.py
@@ -249,6 +249,9 @@ def health() -> Response:
     except exceptions.InputError as exc:
         return Response(response=str(exc), status=http.HTTPStatus.INTERNAL_SERVER_ERROR)
     except GithubException as exc:
-        return Response(response=f"could not communicate with GitHub, {exc}", status=500)
+        return Response(
+            response=f"could not communicate with GitHub, {exc}",
+            status=http.HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
 
     return Response(status=http.HTTPStatus.NO_CONTENT)

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -1,0 +1,410 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Individual checks used to compose job checks."""
+
+from enum import Enum
+from typing import NamedTuple
+
+from github import Github
+from github.Branch import Branch
+from github.Repository import Repository
+
+from . import check, log
+from .comment import remove_quote_lines
+from .github_client import get_branch, get_collaborators
+from .github_client import inject as inject_github_client
+
+BYPASS_ALLOWANCES_KEY = "bypass_pull_request_allowances"
+FAILURE_MESSAGE = (
+    "\n"
+    "This job has failed to pass a repository policy compliance check as defined in "
+    "https://github.com/canonical/repo-policy-compliance. The specific failure is listed "
+    "below. Please update the settings on this project to fix the relevant policy."
+    "\n"
+)
+AUTHORIZATION_STRING_PREFIX = "/canonical/self-hosted-runners/run-workflows"
+EXECUTE_JOB_MESSAGE = (
+    "execution not authorized, a comment from a maintainer or above on the repository approving "
+    "the workflow was not found on a PR from a fork, the comment should include the string "
+    f"'{AUTHORIZATION_STRING_PREFIX} <commit SHA>' where the commit SHA is the SHA of the latest "
+    "commit on the branch"
+)
+
+
+class Result(str, Enum):
+    """The result of a check.
+
+    Attrs:
+        PASS: The check passed.
+        FAIL: The check failed.
+    """
+
+    # Bandit thinks pass is for password
+    PASS = "pass"  # nosec
+    FAIL = "fail"
+
+
+class Report(NamedTuple):
+    """Reports the result of a check.
+
+    Attrs:
+        result: The check result.
+        reason: If the check failed, the reason why it failed.
+    """
+
+    result: Result
+    reason: str | None
+
+
+log.setup()
+
+
+@log.func
+def branch_protected(branch: Branch) -> Report:
+    """Check that the branch has protections enabled.
+
+    Args:
+        branch: The branch to check.
+
+    Returns:
+        Whether the branch has protections enabled.
+    """
+    if not branch.protected:
+        return Report(
+            result=Result.FAIL,
+            reason=(f"{FAILURE_MESSAGE}branch protection not enabled, {branch.name=!r}"),
+        )
+    return Report(result=Result.PASS, reason=None)
+
+
+@log.func
+def signed_commits_required(branch: Branch) -> Report:
+    """Check that the branch requires signed commits.
+
+    Args:
+        branch: The branch to check.
+
+    Returns:
+        Whether the branch requires signed commits.
+    """
+    if not branch.get_required_signatures():
+        return Report(
+            result=Result.FAIL,
+            reason=(f"{FAILURE_MESSAGE}signed commits not required, {branch.name=!r}"),
+        )
+    return Report(result=Result.PASS, reason=None)
+
+
+@log.func
+def unique_commits_signed(
+    branch_name: str, other_branch_name: str, repository: Repository
+) -> Report:
+    """Check that the commits unique to a branch are signed.
+
+    Args:
+        branch_name: The name of the branch to check.
+        other_branch_name: The name of the branch which will be used to exclude commits.
+        repository: The repository the branches are on.
+
+    Returns:
+        Whether the unique commits on the branch are signed.
+    """
+    other_branch_commit_shas = {
+        commit.sha for commit in repository.get_commits(sha=other_branch_name)
+    }
+    branch_commits = repository.get_commits(sha=branch_name)
+    unsigned_unique_branch_commits = (
+        commit
+        for commit in branch_commits
+        if commit.sha not in other_branch_commit_shas
+        and not commit.commit.raw_data["verification"]["verified"]
+    )
+    if first_unsigned_commit := next(unsigned_unique_branch_commits, None):
+        return Report(
+            result=Result.FAIL,
+            reason=(
+                f"{FAILURE_MESSAGE}"
+                f"commit is not signed, {branch_name=!r}, {first_unsigned_commit.sha=!r}"
+            ),
+        )
+
+    return Report(result=Result.PASS, reason=None)
+
+
+@inject_github_client
+@log.func
+def target_branch_protection(
+    github_client: Github, repository_name: str, branch_name: str
+) -> check.Report:
+    """Check that the target branch has appropriate protections.
+
+    Args:
+        github_client: The client to be used for GitHub API interactions.
+        repository_name: The name of the repository to run the check on.
+        branch_name: The name of the branch to check.
+
+    Returns:
+        Whether the branch has appropriate protections.
+    """
+    branch = get_branch(
+        github_client=github_client, repository_name=repository_name, branch_name=branch_name
+    )
+
+    if (protected_report := branch_protected(branch=branch)).result == check.Result.FAIL:
+        return protected_report
+
+    protection = branch.get_protection()
+
+    pull_request_reviews = protection.required_pull_request_reviews
+    if not pull_request_reviews.require_code_owner_reviews:
+        return check.Report(
+            result=check.Result.FAIL,
+            reason=(
+                f"{FAILURE_MESSAGE}"
+                f"codeowner pull request reviews are not required, {branch_name=!r}"
+            ),
+        )
+    if not pull_request_reviews.dismiss_stale_reviews:
+        return check.Report(
+            result=check.Result.FAIL,
+            reason=(f"{FAILURE_MESSAGE}stale reviews are not dismissed, {branch_name=!r}"),
+        )
+    # Check for bypass allowances
+    bypass_allowances = pull_request_reviews.raw_data.get(BYPASS_ALLOWANCES_KEY, {})
+    if any(bypass_allowances.get(key, []) for key in ("users", "teams", "apps")):
+        return check.Report(
+            result=check.Result.FAIL,
+            reason=(f"{FAILURE_MESSAGE}pull request reviews can be bypassed, {branch_name=!r}"),
+        )
+
+    if (
+        signed_commits_report := signed_commits_required(branch=branch)
+    ).result == check.Result.FAIL:
+        return signed_commits_report
+
+    return check.Report(result=check.Result.PASS, reason=None)
+
+
+@inject_github_client
+@log.func
+def source_branch_protection(
+    github_client: Github,
+    repository_name: str,
+    source_repository_name: str,
+    branch_name: str,
+    target_branch_name: str,
+) -> check.Report:
+    """Check that the source branch has appropriate protections.
+
+    Args:
+        github_client: The client to be used for GitHub API interactions.
+        repository_name: The name of the repository to run the check on.
+        source_repository_name: The name of the repository that contains the source branch.
+        branch_name: The name of the branch to check.
+        target_branch_name: The name of the branch that the source branch is proposed to be merged
+            into.
+
+    Returns:
+        Whether the branch has appropriate protections.
+    """
+    # Check for fork
+    if source_repository_name != repository_name:
+        return check.Report(result=check.Result.PASS, reason=None)
+
+    branch = get_branch(
+        github_client=github_client, repository_name=repository_name, branch_name=branch_name
+    )
+
+    if (protected_report := branch_protected(branch=branch)).result == check.Result.FAIL:
+        return protected_report
+
+    if (
+        signed_commits_report := signed_commits_required(branch=branch)
+    ).result == check.Result.FAIL:
+        return signed_commits_report
+
+    repository = github_client.get_repo(repository_name)
+    if (
+        unique_commits_signed_report := unique_commits_signed(
+            branch_name=branch_name,
+            other_branch_name=target_branch_name,
+            repository=repository,
+        )
+    ).result == check.Result.FAIL:
+        return unique_commits_signed_report
+
+    return check.Report(result=check.Result.PASS, reason=None)
+
+
+@inject_github_client
+@log.func
+def branch_protection(
+    github_client: Github,
+    repository_name: str,
+    branch_name: str,
+    commit_sha: str,
+) -> check.Report:
+    """Check that the branch has appropriate protections.
+
+    Args:
+        github_client: The client to be used for GitHub API interactions.
+        repository_name: The name of the repository to run the check on.
+        branch_name: The name of the branch to check.
+        commit_sha: The SHA of the commit that the workflow run is on.
+
+    Returns:
+        Whether the branch has appropriate protections.
+    """
+    branch = get_branch(
+        github_client=github_client, repository_name=repository_name, branch_name=branch_name
+    )
+
+    if (protected_report := branch_protected(branch=branch)).result == check.Result.FAIL:
+        return protected_report
+
+    if (
+        signed_commits_report := signed_commits_required(branch=branch)
+    ).result == check.Result.FAIL:
+        return signed_commits_report
+
+    repository = github_client.get_repo(repository_name)
+    if (
+        unique_commits_signed_report := unique_commits_signed(
+            branch_name=branch_name,
+            other_branch_name=repository.default_branch,
+            repository=repository,
+        )
+    ).result == check.Result.FAIL:
+        return unique_commits_signed_report
+
+    # Check that the commit the job is running on is signed
+    commit = repository.get_commit(sha=commit_sha)
+    if not commit.commit.raw_data["verification"]["verified"]:
+        return check.Report(
+            result=check.Result.FAIL,
+            reason=(
+                f"{FAILURE_MESSAGE}"
+                f"commit the job is running on is not signed, {branch_name=!r}, {commit_sha=!r}"
+            ),
+        )
+
+    return check.Report(result=check.Result.PASS, reason=None)
+
+
+@inject_github_client
+@log.func
+def collaborators(github_client: Github, repository_name: str) -> check.Report:
+    """Check that no outside contributors have higher access than read.
+
+    Args:
+        github_client: The client to be used for GitHub API interactions.
+        repository_name: The name of the repository to run the check on.
+
+    Returns:
+        Whether there are any outside collaborators with higher than read permissions.
+    """
+    repository = github_client.get_repo(repository_name)
+    outside_collaborators = get_collaborators(
+        repository=repository, permission="triage", affiliation="outside"
+    )
+
+    higher_permission_logins = tuple(
+        collaborator["login"]
+        for collaborator in outside_collaborators
+        if collaborator["role_name"] != "read"
+    )
+
+    if higher_permission_logins:
+        return check.Report(
+            result=check.Result.FAIL,
+            reason=(
+                f"{FAILURE_MESSAGE}"
+                "the repository includes outside collaborators with higher permissions than read,"
+                f"{higher_permission_logins=!r}"
+            ),
+        )
+
+    return check.Report(result=check.Result.PASS, reason=None)
+
+
+@inject_github_client
+@log.func
+def execute_job(
+    github_client: Github,
+    repository_name: str,
+    source_repository_name: str,
+    branch_name: str,
+    commit_sha: str,
+) -> check.Report:
+    """Check that the execution of the workflow for a SHA has been granted for a PR from a fork.
+
+    Args:
+        github_client: The client to be used for GitHub API interactions.
+        repository_name: The name of the repository to run the check on.
+        source_repository_name: The name of the repository that contains the source branch.
+        branch_name: The name of the branch that has the PR.
+        commit_sha: The SHA of the commit that the workflow run is on.
+
+    Returns:
+        Whether the workflow run has been approved for the commit SHA.
+    """
+    # Not from a forked repository
+    if repository_name == source_repository_name:
+        return check.Report(result=check.Result.PASS, reason=None)
+
+    # Retrieve PR for the branch
+    repository = github_client.get_repo(repository_name)
+    pulls = repository.get_pulls(state="open")
+    pull_for_branch = next((pull for pull in pulls if pull.head.ref == branch_name), None)
+    if not pull_for_branch:
+        return check.Report(
+            result=check.Result.FAIL,
+            reason=(f"{FAILURE_MESSAGE}no open pull requests for branch {branch_name}"),
+        )
+
+    # Retrieve comments on the PR
+    comments = pull_for_branch.get_issue_comments()
+    if not comments.totalCount:
+        return check.Report(
+            result=check.Result.FAIL,
+            reason=(
+                f"{FAILURE_MESSAGE}"
+                f"no comment found on PR - {EXECUTE_JOB_MESSAGE}, {branch_name=}, {commit_sha=} "
+                f"{pull_for_branch.number=}"
+            ),
+        )
+
+    # Check for authroization comment
+    authorization_string = f"{AUTHORIZATION_STRING_PREFIX} {commit_sha}"
+    authorization_comments = tuple(
+        comment for comment in comments if authorization_string in remove_quote_lines(comment.body)
+    )
+    if not authorization_comments:
+        return check.Report(
+            result=check.Result.FAIL,
+            reason=(
+                f"{FAILURE_MESSAGE}"
+                f"authorization comment not found on PR, expected: {authorization_string} - "
+                f"{EXECUTE_JOB_MESSAGE}, {branch_name=}, {commit_sha=}, {pull_for_branch.number=}"
+            ),
+        )
+
+    # Check that the commenter has maintain or above permissions
+    maintain_logins = {
+        collaborator["login"]
+        for collaborator in get_collaborators(
+            repository=repository, permission="maintain", affiliation="all"
+        )
+    }
+    if not any(comment.user.login in maintain_logins for comment in authorization_comments):
+        return check.Report(
+            result=check.Result.FAIL,
+            reason=(
+                f"{FAILURE_MESSAGE}"
+                "authorization comment from a user that is not a maintainer or above - "
+                f"{EXECUTE_JOB_MESSAGE}, {branch_name=}, {commit_sha=}, {pull_for_branch.number=}"
+            ),
+        )
+
+    return check.Report(result=check.Result.PASS, reason=None)

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -10,6 +10,7 @@ from urllib import parse
 
 from github import BadCredentialsException, Github, GithubException, RateLimitExceededException
 from github.Auth import Token
+from github.Branch import Branch
 from github.Repository import Repository
 
 from .exceptions import GithubClientError, InputError
@@ -113,3 +114,18 @@ def get_collaborators(
     # pylint: enable=protected-access
 
     return outside_collaborators
+
+
+def get_branch(github_client: Github, repository_name: str, branch_name: str) -> Branch:
+    """Get the branch for the check.
+
+    Args:
+        github_client: The client to be used for GitHub API interactions.
+        repository_name: The name of the repository to run the check on.
+        branch_name: The name of the branch to check.
+
+    Returns:
+        The requested branch.
+    """
+    repository = github_client.get_repo(repository_name)
+    return repository.get_branch(branch_name)

--- a/repo_policy_compliance/log.py
+++ b/repo_policy_compliance/log.py
@@ -11,16 +11,16 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def check(func: Callable[P, R]) -> Callable[P, R]:
-    """Log before check and result of check.
+def func(func: Callable[P, R]) -> Callable[P, R]:
+    """Log before func and result of func.
 
     Args:
-        func: The function that executes a check.
+        func: The function that executes a func.
 
     Returns:
-        The function where the check is logged before it starts and the results are logged.
+        The function where the func is logged before it starts and the results are logged.
     """
-    check_name = func.__name__
+    func_name = func.__name__
 
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         """Replace function.
@@ -32,9 +32,9 @@ def check(func: Callable[P, R]) -> Callable[P, R]:
         Returns:
             The return value after calling the wrapped function.
         """
-        logging.info("start check '%s'", check_name)
+        logging.info("start func '%s'", func_name)
         result = func(*args, **kwargs)
-        logging.info("check '%s' finished, result: %s", check_name, result)
+        logging.info("func '%s' finished, result: %s", func_name, result)
         return result
 
     return wrapper

--- a/repo_policy_compliance/log.py
+++ b/repo_policy_compliance/log.py
@@ -1,0 +1,58 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module for logging."""
+
+import logging
+import sys
+from typing import Callable, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def check(func: Callable[P, R]) -> Callable[P, R]:
+    """Log before check and result of check.
+
+    Args:
+        func: The function that executes a check.
+
+    Returns:
+        The function where the check is logged before it starts and the results are logged.
+    """
+    check_name = func.__name__
+
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        """Replace function.
+
+        Args:
+            args: The positional arguments passed to the method
+            kwargs: The keywords arguments passed to the method
+
+        Returns:
+            The return value after calling the wrapped function.
+        """
+        logging.info("start check '%s'", check_name)
+        result = func(*args, **kwargs)
+        logging.info("check '%s' finished, result: %s", check_name, result)
+        return result
+
+    return wrapper
+
+
+def setup() -> None:
+    """Initialise logging for check execution."""
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(asctime)s - %(message)s")
+    handler.setFormatter(formatter)
+
+    # Setup local logging
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+
+    # Setup urllib3 logging
+    urllib3_logger = logging.getLogger("urllib3")
+    urllib3_logger.setLevel(logging.DEBUG)
+    urllib3_logger.addHandler(handler)

--- a/repo_policy_compliance/log.py
+++ b/repo_policy_compliance/log.py
@@ -11,7 +11,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def func(func: Callable[P, R]) -> Callable[P, R]:
+def call(func: Callable[P, R]) -> Callable[P, R]:
     """Log before func and result of func.
 
     Args:

--- a/repo_policy_compliance/policy.py
+++ b/repo_policy_compliance/policy.py
@@ -18,10 +18,12 @@ class JobType(str, Enum):
     Attrs:
         PULL_REQUEST: Policies for pull requests.
         WORKFLOW_DISPATCH: Policies for workflow dispatch jobs.
+        PUSH: Policies for push jobs.
     """
 
     PULL_REQUEST = "pull_request"
     WORKFLOW_DISPATCH = "workflow_dispatch"
+    PUSH = "push"
 
 
 class PullRequestProperty(str, Enum):
@@ -40,8 +42,8 @@ class PullRequestProperty(str, Enum):
     EXECUTE_JOB = "execute_job"
 
 
-class WorkflowDispatchProperty(str, Enum):
-    """The names of the properties for the workflow dispatch portion of the policy document.
+class BranchJobProperty(str, Enum):
+    """The names of the properties for jobs running on a branch portion of the policy document.
 
     Attrs:
         BRANCH_PROTECTION: Branch protection for the branch.
@@ -52,6 +54,10 @@ class WorkflowDispatchProperty(str, Enum):
     COLLABORATORS = "collaborators"
 
 
+WorkflowDispatchProperty = BranchJobProperty
+PushProperty = BranchJobProperty
+
+
 # Using MappingProxyType to make these immutable
 ENABLED_KEY = "enabled"
 ENABLED_RULE = MappingProxyType({ENABLED_KEY: True})
@@ -59,6 +65,7 @@ ALL = MappingProxyType(
     {
         JobType.PULL_REQUEST: {prop: ENABLED_RULE for prop in PullRequestProperty},
         JobType.WORKFLOW_DISPATCH: {prop: ENABLED_RULE for prop in WorkflowDispatchProperty},
+        JobType.PUSH: {prop: ENABLED_RULE for prop in PushProperty},
     }
 )
 
@@ -97,7 +104,7 @@ def check(document: dict) -> Report:
 
 def enabled(
     job_type: JobType,
-    name: PullRequestProperty | WorkflowDispatchProperty,
+    name: PullRequestProperty | WorkflowDispatchProperty | PushProperty,
     policy_document: MappingProxyType,
 ) -> bool:
     """Check whether a given policy is enabled.

--- a/repo_policy_compliance/policy_schema.yaml
+++ b/repo_policy_compliance/policy_schema.yaml
@@ -23,6 +23,14 @@ properties:
       collaborators:
         $ref: "#/$defs/rule"
     additionalProperties: false
+  push:
+    type: object
+    properties:
+      branch_protection:
+        $ref: "#/$defs/rule"
+      collaborators:
+        $ref: "#/$defs/rule"
+    additionalProperties: false
 additionalProperties: false
 $defs:
   rule:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -263,7 +263,7 @@ def fixture_collaborators_with_permission(
 
     # Change the collaborators request to return mixin collaborators
     monkeypatch.setattr(
-        repo_policy_compliance,
+        repo_policy_compliance.check,
         "get_collaborators",
         lambda *_args, **_kwargs: mixin_collabs_with_role_name,
     )

--- a/tests/integration/test_blueprint.py
+++ b/tests/integration/test_blueprint.py
@@ -482,7 +482,7 @@ def test_pull_request_check_run_fail_policy_disabled(
         blueprint.POLICY_ENDPOINT,
         json={
             policy.JobType.PULL_REQUEST: {
-                policy.PullRequestProperty.TARGET_BRANCH_PROTECTION: {policy.ENABLED_KEY: False}
+                prop: {policy.ENABLED_KEY: False} for prop in policy.PullRequestProperty
             }
         },
         headers={"Authorization": f"Bearer {charm_token}"},
@@ -543,7 +543,7 @@ def test_workflow_dispatch_check_run_fail_policy_disabled(
         blueprint.POLICY_ENDPOINT,
         json={
             policy.JobType.WORKFLOW_DISPATCH: {
-                policy.WorkflowDispatchProperty.BRANCH_PROTECTION: {policy.ENABLED_KEY: False}
+                prop: {policy.ENABLED_KEY: False} for prop in policy.WorkflowDispatchProperty
             }
         },
         headers={"Authorization": f"Bearer {charm_token}"},
@@ -602,7 +602,7 @@ def test_push_check_run_policy_disabled(
         blueprint.POLICY_ENDPOINT,
         json={
             policy.JobType.PUSH: {
-                policy.PushProperty.BRANCH_PROTECTION: {policy.ENABLED_KEY: False}
+                prop: {policy.ENABLED_KEY: False} for prop in policy.PushProperty
             }
         },
         headers={"Authorization": f"Bearer {charm_token}"},

--- a/tests/integration/test_blueprint.py
+++ b/tests/integration/test_blueprint.py
@@ -571,7 +571,7 @@ def test_workflow_dispatch_check_run_fail_policy_disabled(
     [f"test-branch/blueprint/push/fail-policy/{uuid4()}"],
     indirect=True,
 )
-def test_push_check_run_fail_policy_disabled(
+def test_push_check_run_policy_disabled(
     client: FlaskClient,
     runner_token: str,
     charm_token: str,

--- a/tests/integration/test_blueprint.py
+++ b/tests/integration/test_blueprint.py
@@ -94,7 +94,7 @@ def test_one_time_token_as_runner(client: FlaskClient, runner_token: str):
     )
 
     assert (
-        runner_token_response.status_code == http.HTTPStatus.FORBIDDEN[0]
+        runner_token_response.status_code == http.HTTPStatus.FORBIDDEN
     ), runner_token_response.data
 
 
@@ -109,7 +109,7 @@ def test_one_time_token(client: FlaskClient, charm_token: str):
         blueprint.ONE_TIME_TOKEN_ENDPOINT, headers={"Authorization": f"Bearer {charm_token}"}
     )
 
-    assert response.status_code == http.HTTPStatus.OK[0], response.data
+    assert response.status_code == http.HTTPStatus.OK, response.data
     assert response.data
 
 
@@ -137,7 +137,7 @@ def test_check_run_twice_same_token(
         headers={"Authorization": f"Bearer {runner_token}"},
     )
 
-    assert first_response.status_code == http.HTTPStatus.NO_CONTENT[0], first_response.data
+    assert first_response.status_code == http.HTTPStatus.NO_CONTENT, first_response.data
 
     second_response = client.post(
         blueprint.CHECK_RUN_ENDPOINT,
@@ -145,7 +145,7 @@ def test_check_run_twice_same_token(
         headers={"Authorization": f"Bearer {runner_token}"},
     )
 
-    assert second_response.status_code == http.HTTPStatus.UNAUTHORIZED[0], second_response.data
+    assert second_response.status_code == http.HTTPStatus.UNAUTHORIZED, second_response.data
 
 
 @pytest.mark.parametrize(
@@ -237,7 +237,7 @@ def test_pull_request_check_run_fail(
         headers={"Authorization": f"Bearer {runner_token}"},
     )
 
-    assert response.status_code == http.HTTPStatus.FORBIDDEN[0], response.data
+    assert response.status_code == http.HTTPStatus.FORBIDDEN, response.data
     assert_.substrings_in_string(
         ("branch protection", "not enabled"), response.data.decode("utf-8")
     )
@@ -282,7 +282,7 @@ def test_branch_check_run_fail(
         headers={"Authorization": f"Bearer {runner_token}"},
     )
 
-    assert response.status_code == http.HTTPStatus.FORBIDDEN[0], response.data
+    assert response.status_code == http.HTTPStatus.FORBIDDEN, response.data
     assert_.substrings_in_string(
         ("branch protection", "not enabled"), response.data.decode("utf-8")
     )
@@ -356,7 +356,7 @@ def test_pull_request_check_run_pass(
         headers={"Authorization": f"Bearer {runner_token}"},
     )
 
-    assert response.status_code == http.HTTPStatus.NO_CONTENT[0], response.data
+    assert response.status_code == http.HTTPStatus.NO_CONTENT, response.data
 
 
 @pytest.mark.parametrize(
@@ -387,7 +387,7 @@ def test_branch_check_run_pass(
         headers={"Authorization": f"Bearer {runner_token}"},
     )
 
-    assert response.status_code == http.HTTPStatus.NO_CONTENT[0], response.data
+    assert response.status_code == http.HTTPStatus.NO_CONTENT, response.data
 
 
 @pytest.mark.parametrize(
@@ -421,11 +421,11 @@ def test_endpoint_method_unauth(endpoint: str, method: str, client: FlaskClient)
     """
     response = getattr(client, method)(endpoint, headers={})
 
-    assert response.status_code == http.HTTPStatus.UNAUTHORIZED[0], response.data
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED, response.data
 
     response = getattr(client, method)(endpoint, headers={"Authorization": "Bearer invalid"})
 
-    assert response.status_code == http.HTTPStatus.UNAUTHORIZED[0], response.data
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED, response.data
 
 
 def test_policy_invalid(client: FlaskClient, charm_token: str):
@@ -475,7 +475,7 @@ def test_pull_request_check_run_fail_policy_disabled(
         headers={"Authorization": f"Bearer {runner_token}"},
     )
 
-    assert fail_response.status_code == http.HTTPStatus.FORBIDDEN[0], fail_response.data
+    assert fail_response.status_code == http.HTTPStatus.FORBIDDEN, fail_response.data
 
     # Disable branch protection policy
     policy_response = client.post(
@@ -488,7 +488,7 @@ def test_pull_request_check_run_fail_policy_disabled(
         headers={"Authorization": f"Bearer {charm_token}"},
     )
 
-    assert policy_response.status_code == http.HTTPStatus.NO_CONTENT[0], policy_response.data
+    assert policy_response.status_code == http.HTTPStatus.NO_CONTENT, policy_response.data
 
     disabled_response = client.post(
         blueprint.PULL_REQUEST_CHECK_RUN_ENDPOINT,
@@ -504,7 +504,7 @@ def test_pull_request_check_run_fail_policy_disabled(
         },
     )
 
-    assert disabled_response.status_code == http.HTTPStatus.NO_CONTENT[0], disabled_response.data
+    assert disabled_response.status_code == http.HTTPStatus.NO_CONTENT, disabled_response.data
 
 
 @pytest.mark.parametrize(
@@ -536,7 +536,7 @@ def test_workflow_dispatch_check_run_fail_policy_disabled(
         headers={"Authorization": f"Bearer {runner_token}"},
     )
 
-    assert fail_response.status_code == http.HTTPStatus.FORBIDDEN[0], fail_response.data
+    assert fail_response.status_code == http.HTTPStatus.FORBIDDEN, fail_response.data
 
     # Disable branch protection policy
     policy_response = client.post(
@@ -549,7 +549,7 @@ def test_workflow_dispatch_check_run_fail_policy_disabled(
         headers={"Authorization": f"Bearer {charm_token}"},
     )
 
-    assert policy_response.status_code == http.HTTPStatus.NO_CONTENT[0], policy_response.data
+    assert policy_response.status_code == http.HTTPStatus.NO_CONTENT, policy_response.data
 
     disabled_response = client.post(
         blueprint.WORKFLOW_DISPATCH_CHECK_RUN_ENDPOINT,
@@ -563,7 +563,7 @@ def test_workflow_dispatch_check_run_fail_policy_disabled(
         },
     )
 
-    assert disabled_response.status_code == http.HTTPStatus.NO_CONTENT[0], disabled_response.data
+    assert disabled_response.status_code == http.HTTPStatus.NO_CONTENT, disabled_response.data
 
 
 @pytest.mark.parametrize(
@@ -595,7 +595,7 @@ def test_push_check_run_fail_policy_disabled(
         headers={"Authorization": f"Bearer {runner_token}"},
     )
 
-    assert fail_response.status_code == http.HTTPStatus.FORBIDDEN[0], fail_response.data
+    assert fail_response.status_code == http.HTTPStatus.FORBIDDEN, fail_response.data
 
     # Disable branch protection policy
     policy_response = client.post(
@@ -608,7 +608,7 @@ def test_push_check_run_fail_policy_disabled(
         headers={"Authorization": f"Bearer {charm_token}"},
     )
 
-    assert policy_response.status_code == http.HTTPStatus.NO_CONTENT[0], policy_response.data
+    assert policy_response.status_code == http.HTTPStatus.NO_CONTENT, policy_response.data
 
     disabled_response = client.post(
         blueprint.PUSH_CHECK_RUN_ENDPOINT,
@@ -622,7 +622,7 @@ def test_push_check_run_fail_policy_disabled(
         },
     )
 
-    assert disabled_response.status_code == http.HTTPStatus.NO_CONTENT[0], disabled_response.data
+    assert disabled_response.status_code == http.HTTPStatus.NO_CONTENT, disabled_response.data
 
 
 @pytest.mark.parametrize(
@@ -650,4 +650,4 @@ def test_health(client: FlaskClient):
     """
     response = client.get(blueprint.HEALTH_ENDPOINT)
 
-    assert response.status_code == http.HTTPStatus.NO_CONTENT[0], response.data
+    assert response.status_code == http.HTTPStatus.NO_CONTENT, response.data

--- a/tests/integration/test_blueprint.py
+++ b/tests/integration/test_blueprint.py
@@ -251,7 +251,7 @@ def test_pull_request_check_run_fail(
         pytest.param(
             f"test-branch/blueprint/workflow-dispatch/fail/{uuid4()}",
             blueprint.PUSH_CHECK_RUN_ENDPOINT,
-            id="pushh",
+            id="push",
         ),
     ],
     indirect=["github_branch"],

--- a/tests/integration/test_branch_protection.py
+++ b/tests/integration/test_branch_protection.py
@@ -11,7 +11,7 @@ from github import Consts
 from github.Branch import Branch
 from github.Repository import Repository
 
-from repo_policy_compliance import Result, branch_protection
+from repo_policy_compliance.check import Result, branch_protection
 
 from .. import assert_
 from .types_ import BranchWithProtection

--- a/tests/integration/test_collaborators.py
+++ b/tests/integration/test_collaborators.py
@@ -7,7 +7,7 @@ import itertools
 
 import pytest
 
-from repo_policy_compliance import Result, collaborators
+from repo_policy_compliance.check import Result, collaborators
 
 from .. import assert_
 from .types_ import RequestedCollaborator

--- a/tests/integration/test_execute_job.py
+++ b/tests/integration/test_execute_job.py
@@ -15,7 +15,7 @@ from github.PullRequest import PullRequest
 from github.Repository import Repository
 
 import repo_policy_compliance
-from repo_policy_compliance import AUTHORIZATION_STRING_PREFIX, Result, execute_job
+from repo_policy_compliance.check import AUTHORIZATION_STRING_PREFIX, Result, execute_job
 
 from .. import assert_
 
@@ -211,7 +211,7 @@ def test_fail_forked_comment_from_wrong_user_on_pr(
 
         # Change the collaborators request to return no collaborators
         monkeypatch.setattr(
-            repo_policy_compliance, "get_collaborators", lambda *_args, **_kwargs: []
+            repo_policy_compliance.check, "get_collaborators", lambda *_args, **_kwargs: []
         )
 
     # The github_client is injected

--- a/tests/integration/test_github_client.py
+++ b/tests/integration/test_github_client.py
@@ -7,7 +7,7 @@ import typing
 
 import pytest
 
-from repo_policy_compliance import target_branch_protection
+from repo_policy_compliance.check import target_branch_protection
 from repo_policy_compliance.exceptions import GithubClientError, InputError
 from repo_policy_compliance.github_client import GITHUB_TOKEN_ENV_NAME
 

--- a/tests/integration/test_pull_request.py
+++ b/tests/integration/test_pull_request.py
@@ -9,7 +9,8 @@ import pytest
 from github.Branch import Branch
 from github.Repository import Repository
 
-from repo_policy_compliance import PullRequestInput, Result, policy, pull_request
+from repo_policy_compliance import PullRequestInput, policy, pull_request
+from repo_policy_compliance.check import Result
 
 from .types_ import BranchWithProtection, RequestedCollaborator
 

--- a/tests/integration/test_pull_request.py
+++ b/tests/integration/test_pull_request.py
@@ -55,7 +55,7 @@ def test_invalid_policy():
     ],
     indirect=["github_branch"],
 )
-def test_fail_target_branch(
+def test_target_branch(
     github_branch: Branch,
     policy_enabled: bool,
     expected_result: Result,
@@ -112,7 +112,7 @@ def test_fail_target_branch(
     indirect=["github_branch", "protected_github_branch", "another_github_branch"],
 )
 @pytest.mark.usefixtures("protected_github_branch")
-def test_fail_source_branch(
+def test_source_branch(
     github_branch: Branch,
     github_repository_name: str,
     another_github_branch: Branch,
@@ -170,7 +170,7 @@ def test_fail_source_branch(
     indirect=["github_branch", "protected_github_branch", "collaborators_with_permission"],
 )
 @pytest.mark.usefixtures("protected_github_branch", "collaborators_with_permission")
-def test_fail_collaborators(
+def test_collaborators(
     github_branch: Branch,
     github_repository_name: str,
     policy_enabled: bool,
@@ -227,7 +227,7 @@ def test_fail_collaborators(
 )
 @pytest.mark.usefixtures("protected_github_branch")
 # All the arguments are required for the test
-def test_fail_execute_job(  # pylint: disable=too-many-arguments
+def test_execute_job(  # pylint: disable=too-many-arguments
     github_branch: Branch,
     github_repository_name: str,
     forked_github_branch: Branch,

--- a/tests/integration/test_push.py
+++ b/tests/integration/test_push.py
@@ -12,7 +12,8 @@ from uuid import uuid4
 import pytest
 from github.Branch import Branch
 
-from repo_policy_compliance import PushInput, Result, policy, push
+from repo_policy_compliance import PushInput, policy, push
+from repo_policy_compliance.check import Result
 
 from .types_ import BranchWithProtection, RequestedCollaborator
 

--- a/tests/integration/test_push.py
+++ b/tests/integration/test_push.py
@@ -56,7 +56,7 @@ def test_invalid_policy():
     ],
     indirect=["github_branch"],
 )
-def test_fail_branch(
+def test_branch(
     github_branch: Branch,
     policy_enabled: bool,
     expected_result: Result,
@@ -109,7 +109,7 @@ def test_fail_branch(
     indirect=["github_branch", "protected_github_branch", "collaborators_with_permission"],
 )
 @pytest.mark.usefixtures("protected_github_branch", "collaborators_with_permission")
-def test_fail_collaborators(
+def test_collaborators(
     github_branch: Branch,
     github_repository_name: str,
     policy_enabled: bool,

--- a/tests/integration/test_push.py
+++ b/tests/integration/test_push.py
@@ -1,14 +1,18 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Tests for the workflow_dispatch function."""
+"""Tests for the push function."""
+
+# These tests are similar to workflow dispatch tests, in tests some duplication is ok to make the
+# tests easier to understand
+# pylint: disable=duplicate-code
 
 from uuid import uuid4
 
 import pytest
 from github.Branch import Branch
 
-from repo_policy_compliance import Result, WorkflowDispatchInput, policy, workflow_dispatch
+from repo_policy_compliance import PushInput, Result, policy, push
 
 from .types_ import BranchWithProtection, RequestedCollaborator
 
@@ -16,13 +20,13 @@ from .types_ import BranchWithProtection, RequestedCollaborator
 def test_invalid_policy():
     """
     arrange: given invalid policy
-    act: when workflow_dispatch is called with the policy
+    act: when push is called with the policy
     assert: then a fail report is returned.
     """
     policy_document = {"invalid": "value"}
 
-    report = workflow_dispatch(
-        input_=WorkflowDispatchInput(
+    report = push(
+        input_=PushInput(
             repository_name="repository 1",
             branch_name="branch 1",
             commit_sha="commit sha 1",
@@ -37,13 +41,13 @@ def test_invalid_policy():
     "github_branch, policy_enabled, expected_result",
     [
         pytest.param(
-            f"test-branch/workflow_dispatch/branch-fail-enabled/{uuid4()}",
+            f"test-branch/push/branch-fail-enabled/{uuid4()}",
             True,
             Result.FAIL,
             id="policy enabled",
         ),
         pytest.param(
-            f"test-branch/workflow_dispatch/branch-fail-disabled/{uuid4()}",
+            f"test-branch/push/branch-fail-disabled/{uuid4()}",
             False,
             Result.PASS,
             id="policy disabled",
@@ -59,17 +63,17 @@ def test_fail_branch(
 ):
     """
     arrange: given a branch that is not compliant and whether the policy is enabled
-    act: when workflow_dispatch is called with the policy
+    act: when push is called with the policy
     assert: then the expected report is returned.
     """
     policy_document = {
-        policy.JobType.WORKFLOW_DISPATCH: {
-            policy.WorkflowDispatchProperty.BRANCH_PROTECTION: {policy.ENABLED_KEY: policy_enabled}
+        policy.JobType.PUSH: {
+            policy.PushProperty.BRANCH_PROTECTION: {policy.ENABLED_KEY: policy_enabled}
         }
     }
 
-    report = workflow_dispatch(
-        input_=WorkflowDispatchInput(
+    report = push(
+        input_=PushInput(
             repository_name=github_repository_name,
             branch_name=github_branch.name,
             commit_sha="sha 1",
@@ -85,7 +89,7 @@ def test_fail_branch(
     "expected_result",
     [
         pytest.param(
-            f"test-branch/workflow_dispatch/collaborators-fail-enabled/{uuid4()}",
+            f"test-branch/push/collaborators-fail-enabled/{uuid4()}",
             BranchWithProtection(),
             RequestedCollaborator("admin", "admin"),
             True,
@@ -93,7 +97,7 @@ def test_fail_branch(
             id="policy enabled",
         ),
         pytest.param(
-            f"test-branch/workflow_dispatch/collaborators-fail-disabled/{uuid4()}",
+            f"test-branch/push/collaborators-fail-disabled/{uuid4()}",
             BranchWithProtection(),
             RequestedCollaborator("admin", "admin"),
             False,
@@ -113,17 +117,17 @@ def test_fail_collaborators(
     """
     arrange: given a branch that are compliant and outside collaborators with more than read
         permission and whether the policy is enabled
-    act: when workflow_dispatch is called with the policy
+    act: when push is called with the policy
     assert: then the expected report is returned.
     """
     policy_document = {
-        policy.JobType.WORKFLOW_DISPATCH: {
-            policy.WorkflowDispatchProperty.COLLABORATORS: {policy.ENABLED_KEY: policy_enabled}
+        policy.JobType.PUSH: {
+            policy.PushProperty.COLLABORATORS: {policy.ENABLED_KEY: policy_enabled}
         }
     }
 
-    report = workflow_dispatch(
-        input_=WorkflowDispatchInput(
+    report = push(
+        input_=PushInput(
             repository_name=github_repository_name,
             branch_name=github_branch.name,
             commit_sha=github_branch.commit.sha,
@@ -136,7 +140,7 @@ def test_fail_collaborators(
 
 @pytest.mark.parametrize(
     "github_branch, protected_github_branch",
-    [pytest.param(f"test-branch/workflow_dispatch/pass/{uuid4()}", BranchWithProtection())],
+    [pytest.param(f"test-branch/push/pass/{uuid4()}", BranchWithProtection())],
     indirect=True,
 )
 @pytest.mark.usefixtures("protected_github_branch")
@@ -145,11 +149,11 @@ def test_pass(
 ):
     """
     arrange: given a branch and repository that is compliant
-    act: when workflow_dispatch is called
+    act: when push is called
     assert: then a pass report is returned.
     """
-    report = workflow_dispatch(
-        input_=WorkflowDispatchInput(
+    report = push(
+        input_=PushInput(
             repository_name=github_repository_name,
             branch_name=github_branch.name,
             commit_sha=github_branch.commit.sha,
@@ -157,5 +161,5 @@ def test_pass(
     )
 
     assert report.result == Result.PASS
-    assert repr("workflow_dispatch") in caplog.text
+    assert repr("push") in caplog.text
     assert repr(report) in caplog.text

--- a/tests/integration/test_source_branch_protection.py
+++ b/tests/integration/test_source_branch_protection.py
@@ -10,7 +10,7 @@ import pytest
 from github.Branch import Branch
 from github.Repository import Repository
 
-from repo_policy_compliance import Result, source_branch_protection
+from repo_policy_compliance.check import Result, source_branch_protection
 
 from .. import assert_
 from .types_ import BranchWithProtection

--- a/tests/integration/test_target_branch_protection.py
+++ b/tests/integration/test_target_branch_protection.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 import pytest
 from github.Branch import Branch
 
-from repo_policy_compliance import Result, target_branch_protection
+from repo_policy_compliance.check import Result, target_branch_protection
 
 from .. import assert_
 from .types_ import BranchWithProtection

--- a/tests/integration/test_workflow_dispatch.py
+++ b/tests/integration/test_workflow_dispatch.py
@@ -52,7 +52,7 @@ def test_invalid_policy():
     ],
     indirect=["github_branch"],
 )
-def test_fail_branch(
+def test_branch(
     github_branch: Branch,
     policy_enabled: bool,
     expected_result: Result,
@@ -105,7 +105,7 @@ def test_fail_branch(
     indirect=["github_branch", "protected_github_branch", "collaborators_with_permission"],
 )
 @pytest.mark.usefixtures("protected_github_branch", "collaborators_with_permission")
-def test_fail_collaborators(
+def test_collaborators(
     github_branch: Branch,
     github_repository_name: str,
     policy_enabled: bool,

--- a/tests/integration/test_workflow_dispatch.py
+++ b/tests/integration/test_workflow_dispatch.py
@@ -8,7 +8,8 @@ from uuid import uuid4
 import pytest
 from github.Branch import Branch
 
-from repo_policy_compliance import Result, WorkflowDispatchInput, policy, workflow_dispatch
+from repo_policy_compliance import WorkflowDispatchInput, policy, workflow_dispatch
+from repo_policy_compliance.check import Result
 
 from .types_ import BranchWithProtection, RequestedCollaborator
 

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from github import Github, GithubException, RateLimitExceededException
 
-from repo_policy_compliance import target_branch_protection
+from repo_policy_compliance.check import target_branch_protection
 from repo_policy_compliance.exceptions import GithubClientError
 
 GITHUB_REPOSITORY_NAME = "test/repository"

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -30,6 +30,9 @@ from .. import assert_
                 policy.JobType.WORKFLOW_DISPATCH: {
                     name: {**policy.ENABLED_RULE} for name in policy.WorkflowDispatchProperty
                 },
+                policy.JobType.PUSH: {
+                    name: {**policy.ENABLED_RULE} for name in policy.PushProperty
+                },
             },
             True,
             None,
@@ -55,6 +58,7 @@ from .. import assert_
         for job_type, name in chain(
             zip(repeat(policy.JobType.PULL_REQUEST), policy.PullRequestProperty),
             zip(repeat(policy.JobType.WORKFLOW_DISPATCH), policy.WorkflowDispatchProperty),
+            zip(repeat(policy.JobType.PUSH), policy.PushProperty),
         )
     ]
     + [
@@ -67,6 +71,7 @@ from .. import assert_
         for job_type, name in chain(
             zip(repeat(policy.JobType.PULL_REQUEST), policy.PullRequestProperty),
             zip(repeat(policy.JobType.WORKFLOW_DISPATCH), policy.WorkflowDispatchProperty),
+            zip(repeat(policy.JobType.PUSH), policy.PushProperty),
         )
     ],
 )


### PR DESCRIPTION
This PR adds support for the [push](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push) GitHub action. The `push` function is added as a new function and exposed as an endpoint on the blueprint. The code for both is similar to `workflow_dispatch`. The reason for not using an alias is that this would make the code more difficult to understand and more complicated since both of them have a separate entry in the policy document. Some of the data structures are re-used via alias to reduce duplicate code and still enable diverging checks between workflow dispatch and on push in the future.

This PR also makes some structual changes by moving the individual checks that the job checks are composed of into a separate module and also moves the logging functionality to a separate module.