### PR TITLE
Forks from contributors

### DIFF
--- a/repo_policy_compliance/blueprint.py
+++ b/repo_policy_compliance/blueprint.py
@@ -246,7 +246,7 @@ def health() -> Response:
     try:
         client = github_client.get()
         client.get_repo("canonical/repo-policy-compliance")
-    except exceptions.InputError as exc:
+    except exceptions.ConfigurationError as exc:
         return Response(response=str(exc), status=http.HTTPStatus.INTERNAL_SERVER_ERROR)
     except GithubException as exc:
         return Response(

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -327,7 +327,7 @@ def _branch_external_fork(
 ) -> bool:
     """Check whether a branch is an external fork.
 
-    A external fork is a fork that is not owned by a user who is also a collaborator or above on
+    A external fork is a fork that is not owned by a user who is also a maintainer or above on
     the repository.
 
     Args:

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -342,7 +342,7 @@ def _branch_external_fork(
         return False
 
     # Check if the owner of the fork is also a maintainer or above on the repo
-    if source_repository_name in maintain_logins:
+    if source_repository_name.split("/")[0] in maintain_logins:
         return False
 
     return True

--- a/repo_policy_compliance/exceptions.py
+++ b/repo_policy_compliance/exceptions.py
@@ -12,5 +12,9 @@ class InputError(BaseError):
     """Input is missing or unexpected."""
 
 
+class ConfigurationError(BaseError):
+    """There is a problem with configuration."""
+
+
 class GithubClientError(BaseError):
     """Error occurred on Github API."""

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -13,7 +13,7 @@ from github.Auth import Token
 from github.Branch import Branch
 from github.Repository import Repository
 
-from .exceptions import GithubClientError, InputError
+from .exceptions import ConfigurationError, GithubClientError
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -29,11 +29,11 @@ def get() -> Github:
         A GitHub client that is configured with a token from the environment.
 
     Raises:
-        InputError: If the GitHub token environment variable is not provided or empty.
+        ConfigurationError: If the GitHub token environment variable is not provided or empty.
     """
     github_token = os.getenv(GITHUB_TOKEN_ENV_NAME)
     if not github_token:
-        raise InputError(
+        raise ConfigurationError(
             f"The {GITHUB_TOKEN_ENV_NAME} environment variable was not provided or empty, "
             f"it is needed for interactions with GitHub, got: {github_token!r}"
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -269,3 +269,15 @@ def fixture_collaborators_with_permission(
     )
 
     return mixin_collabs_with_role_name
+
+
+@pytest.fixture
+def make_fork_branch_external(monkeypatch: pytest.MonkeyPatch):
+    """Make sure that _branch_external_fork returns True."""
+
+    # Change the collaborators request to return mixin collaborators
+    monkeypatch.setattr(
+        repo_policy_compliance.check,
+        "_branch_external_fork",
+        lambda *_args, **_kwargs: True,
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -274,8 +274,6 @@ def fixture_collaborators_with_permission(
 @pytest.fixture
 def make_fork_branch_external(monkeypatch: pytest.MonkeyPatch):
     """Make sure that _branch_external_fork returns True."""
-
-    # Change the collaborators request to return mixin collaborators
     monkeypatch.setattr(
         repo_policy_compliance.check,
         "_branch_external_fork",

--- a/tests/integration/test_execute_job.py
+++ b/tests/integration/test_execute_job.py
@@ -3,8 +3,8 @@
 
 """Tests for the execute_job function."""
 
-# The tests in this file have to rely on many fixtures
-# pylint: disable=too-many-arguments
+# The tests in this file have to rely on many fixtures, need access to private function to test it
+# pylint: disable=too-many-arguments,protected-access
 
 from uuid import uuid4
 

--- a/tests/integration/test_execute_job.py
+++ b/tests/integration/test_execute_job.py
@@ -310,6 +310,7 @@ def test_pass_main_repo(
     [f"test-branch/execute-job/fork-branch/{uuid4()}"],
     indirect=True,
 )
+@pytest.mark.usefixtures("make_fork_branch_external")
 def test_pass_fork(
     forked_github_repository: Repository,
     github_repository: Repository,

--- a/tests/integration/test_execute_job.py
+++ b/tests/integration/test_execute_job.py
@@ -6,7 +6,6 @@
 # The tests in this file have to rely on many fixtures
 # pylint: disable=too-many-arguments
 
-import random
 from uuid import uuid4
 
 import pytest
@@ -17,7 +16,6 @@ from github.Repository import Repository
 
 import repo_policy_compliance
 from repo_policy_compliance.check import AUTHORIZATION_STRING_PREFIX, Result, execute_job
-from repo_policy_compliance.github_client import get_collaborators
 
 from .. import assert_
 

--- a/tests/integration/test_execute_job.py
+++ b/tests/integration/test_execute_job.py
@@ -21,6 +21,47 @@ from .. import assert_
 
 
 @pytest.mark.parametrize(
+    "repository_name, source_repository_name, maintain_logins, expected_result",
+    [
+        pytest.param("repo-1/name-1", "repo-1/name-1", set(), False, id="repo names match"),
+        pytest.param(
+            "repo-1/name-1",
+            "user-1/name-1",
+            {"user-1"},
+            False,
+            id="repo names don't match, owner in maintain logins",
+        ),
+        pytest.param(
+            "repo-1/name-1",
+            "user-1/name-1",
+            set(),
+            True,
+            id="repo names don't match, owner not in maintain logins",
+        ),
+    ],
+)
+def test__branch_external_fork(
+    repository_name: str,
+    source_repository_name: str,
+    maintain_logins: set[str],
+    expected_result: bool,
+):
+    """
+    arrange: given repository name, source repository name and maintain logins
+    act: when repository name, source repository name and maintain logins are passed to
+        _branch_external_fork
+    assert: then the expected result is returned.
+    """
+    returned_result = repo_policy_compliance.check._branch_external_fork(
+        repository_name=repository_name,
+        source_repository_name=source_repository_name,
+        maintain_logins=maintain_logins,
+    )
+
+    assert returned_result == expected_result
+
+
+@pytest.mark.parametrize(
     "forked_github_branch",
     [f"test-branch/execute-job/no-pr/{uuid4()}"],
     indirect=True,

--- a/tests/integration/test_execute_job.py
+++ b/tests/integration/test_execute_job.py
@@ -185,6 +185,7 @@ def test_fail_forked_quoted_authorizationr(
     [f"test-branch/execute-job/comment-from-wrong-user-on-pr/{uuid4()}"],
     indirect=True,
 )
+@pytest.mark.usefixtures("make_fork_branch_external")
 def test_fail_forked_comment_from_wrong_user_on_pr(
     forked_github_repository: Repository,
     github_repository: Repository,

--- a/tests/integration/test_github_client.py
+++ b/tests/integration/test_github_client.py
@@ -8,7 +8,7 @@ import typing
 import pytest
 
 from repo_policy_compliance.check import target_branch_protection
-from repo_policy_compliance.exceptions import GithubClientError, InputError
+from repo_policy_compliance.exceptions import ConfigurationError, GithubClientError
 from repo_policy_compliance.github_client import GITHUB_TOKEN_ENV_NAME
 
 from .. import assert_
@@ -17,7 +17,9 @@ from .. import assert_
 @pytest.mark.parametrize(
     "github_token_value, exception_context, exception_message",
     [
-        pytest.param("", pytest.raises(InputError), "was not provided", id="github_token empty"),
+        pytest.param(
+            "", pytest.raises(ConfigurationError), "was not provided", id="github_token empty"
+        ),
         pytest.param(
             None, pytest.raises(GithubClientError), "Bad Credential error", id="github_token none"
         ),

--- a/tests/integration/test_pull_request.py
+++ b/tests/integration/test_pull_request.py
@@ -225,7 +225,7 @@ def test_collaborators(
     ],
     indirect=["github_branch", "protected_github_branch", "forked_github_branch"],
 )
-@pytest.mark.usefixtures("protected_github_branch")
+@pytest.mark.usefixtures("protected_github_branch", "make_fork_branch_external")
 # All the arguments are required for the test
 def test_execute_job(  # pylint: disable=too-many-arguments
     github_branch: Branch,


### PR DESCRIPTION
Changes the `execute_job` check to no longer require a comment from a maintainer or above on a repo if the fork is from a maintainer or above on the repository. Since the maintainer can issue the comment anyway, there is no change in the security posture.

Also fixes a minor issue where a misconfigured environment led to an `InputError`, `ConfigurationError` is raised instead now.