### PR TITLE
remove codeowner approval requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ The module exposes several functions to check for compliance with the following
 policies:
 
 * `target_branch_protection`: That the branch targeted by a pull request has
-  protection enabled, requires reviews by the code owner, stale reviews are
-  dismissed, that rules cannot be bypassed and that signed commits are
-  required.
+  protection enabled, stale reviews are dismissed, that rules cannot be bypassed
+  and that signed commits are required.
 * `source_branch_protection`: That the branch containing the commits to be
   merged has protections enabled and requires signed commits. Additionally, all
   commits on the branch and not on the target branch must be signed. Not

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -157,14 +157,6 @@ def target_branch_protection(
     protection = branch.get_protection()
 
     pull_request_reviews = protection.required_pull_request_reviews
-    if not pull_request_reviews.require_code_owner_reviews:
-        return Report(
-            result=Result.FAIL,
-            reason=(
-                f"{FAILURE_MESSAGE}"
-                f"codeowner pull request reviews are not required, {branch_name=!r}"
-            ),
-        )
     if not pull_request_reviews.dismiss_stale_reviews:
         return Report(
             result=Result.FAIL,

--- a/tests/integration/branch_protection.py
+++ b/tests/integration/branch_protection.py
@@ -18,7 +18,6 @@ def edit(branch: Branch, branch_with_protection: BranchWithProtection) -> None:
     """
     if branch_with_protection.bypass_pull_request_allowance_disabled:
         branch.edit_protection(
-            require_code_owner_reviews=branch_with_protection.require_code_owner_reviews,
             dismiss_stale_reviews=branch_with_protection.dismiss_stale_reviews_enabled,
             # This seems to be required as of version 1.59 of PyGithub, without it the API returns
             # an error indicating that None is not a valid value for bypass pull request
@@ -29,7 +28,6 @@ def edit(branch: Branch, branch_with_protection: BranchWithProtection) -> None:
         )
     else:
         branch.edit_protection(
-            require_code_owner_reviews=branch_with_protection.require_code_owner_reviews,
             dismiss_stale_reviews=branch_with_protection.dismiss_stale_reviews_enabled,
             users_bypass_pull_request_allowances=[  # type: ignore
                 "gregory-schiano",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -227,7 +227,6 @@ def protected_github_branch_with_commit_in_ci(
     # Can't use protected_github_branch since the commit needs to be done before the branch
     # protections are applied
     branch_with_protection = BranchWithProtection(
-        require_code_owner_reviews=False,
         dismiss_stale_reviews_enabled=False,
         bypass_pull_request_allowance_disabled=True,
     )

--- a/tests/integration/test_branch_protection.py
+++ b/tests/integration/test_branch_protection.py
@@ -101,10 +101,7 @@ def fixture_branch_for_commit_not_signed_fail(
     post_parameters = {
         "required_status_checks": None,
         "enforce_admins": None,
-        "required_pull_request_reviews": {
-            "dismiss_stale_reviews": False,
-            "require_code_owner_reviews": False,
-        },
+        "required_pull_request_reviews": {"dismiss_stale_reviews": False},
         "restrictions": None,
     }
     # pylint: disable=protected-access

--- a/tests/integration/test_target_branch_protection.py
+++ b/tests/integration/test_target_branch_protection.py
@@ -25,12 +25,6 @@ from .types_ import BranchWithProtection
             id="branch_protection disabled",
         ),
         pytest.param(
-            f"test-branch/target-branch/no-code-owner-review/{uuid4()}",
-            BranchWithProtection(require_code_owner_reviews=False),
-            ("codeowner", "pull request", "review", "not required"),
-            id="code-owner missing",
-        ),
-        pytest.param(
             f"test-branch/target-branch/stale-review-not-dismissed/{uuid4()}",
             BranchWithProtection(dismiss_stale_reviews_enabled=False),
             ("stale", "reviews", "not dismissed"),

--- a/tests/integration/types_.py
+++ b/tests/integration/types_.py
@@ -13,7 +13,6 @@ class BranchWithProtection:
 
     Attributes:
         branch_protection_enabled: True if we need to enable branch protection enabled.
-        require_code_owner_reviews: True if branch requires review from code owner.
         dismiss_stale_reviews_enabled: True if branch dismisses stale reviews.
         bypass_pull_request_allowance_disabled: True if users/teams/apps are allowed to bypass
             pull requests.
@@ -21,7 +20,6 @@ class BranchWithProtection:
     """
 
     branch_protection_enabled: bool = True
-    require_code_owner_reviews: bool = True
     dismiss_stale_reviews_enabled: bool = True
     bypass_pull_request_allowance_disabled: bool = True
     required_signatures_enabled: bool = True


### PR DESCRIPTION
Removes the requirements for code owner review since requiring reviews already ensures that someone with write or above level access to the repo needs to review a PR