### PR TITLE
make policies default to be enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ These policies are designed for workflow runs in the context of a pull request.
 Each of `pull_request`, `workflow_dispatch` and `push` accept a
 `policy_document` argument which can be used to change which policies are
 enabled. If supplied, it should be a dictionary that complies with the
-[policy JSON schema](repo_policy_compliance/policy_schema.yaml)
+[policy JSON schema](repo_policy_compliance/policy_schema.yaml).
+
+If nothing is supplied for a particular policy (e.g.,
+`pull_request.target_branch_protection`) it is treated as enabled.
 
 ## Flask Blueprint
 

--- a/repo_policy_compliance/policy.py
+++ b/repo_policy_compliance/policy.py
@@ -117,6 +117,8 @@ def enabled(
     Returns:
         Whether the policy is enabled in the document.
     """
+    if job_type not in policy_document or name not in policy_document[job_type]:
+        return True
     return (
         job_type in policy_document
         and name in policy_document[job_type]

--- a/tests/integration/test_pull_request.py
+++ b/tests/integration/test_pull_request.py
@@ -70,7 +70,10 @@ def test_target_branch(
         policy.JobType.PULL_REQUEST: {
             policy.PullRequestProperty.TARGET_BRANCH_PROTECTION: {
                 policy.ENABLED_KEY: policy_enabled
-            }
+            },
+            policy.PullRequestProperty.SOURCE_BRANCH_PROTECTION: {policy.ENABLED_KEY: False},
+            policy.PullRequestProperty.COLLABORATORS: {policy.ENABLED_KEY: False},
+            policy.PullRequestProperty.EXECUTE_JOB: {policy.ENABLED_KEY: False},
         }
     }
 


### PR DESCRIPTION
Changes the default for a particular policy to be enabled if nothing is supplied for it in the policy. Previously, if an incomplete policy document was supplied, all policies that are not in the policy document were treated as disabled which might be unexpected for users.