### PR TITLE
remove requirement for commits in a branch not on the default branch to be signed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.0.0"
+version = "1.1.0"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -259,17 +259,8 @@ def branch_protection(
     if (signed_commits_report := signed_commits_required(branch=branch)).result == Result.FAIL:
         return signed_commits_report
 
-    repository = github_client.get_repo(repository_name)
-    if (
-        unique_commits_signed_report := unique_commits_signed(
-            branch_name=branch_name,
-            other_branch_name=repository.default_branch,
-            repository=repository,
-        )
-    ).result == Result.FAIL:
-        return unique_commits_signed_report
-
     # Check that the commit the job is running on is signed
+    repository = github_client.get_repo(repository_name)
     commit = repository.get_commit(sha=commit_sha)
     if not commit.commit.raw_data["verification"]["verified"]:
         return Report(

--- a/tests/integration/test_branch_protection.py
+++ b/tests/integration/test_branch_protection.py
@@ -18,37 +18,26 @@ from .types_ import BranchWithProtection
 
 
 @pytest.mark.parametrize(
-    "github_branch, protected_github_branch, add_commit, reason_string_array",
+    "github_branch, protected_github_branch, reason_string_array",
     [
         pytest.param(
             f"test-branch/branch/not-protected/{uuid4()}",
             BranchWithProtection(branch_protection_enabled=False),
-            False,
             ("not enabled"),
             id="branch_protection disabled",
         ),
         pytest.param(
             f"test-branch/branch/requires-signature/{uuid4()}",
             BranchWithProtection(required_signatures_enabled=False),
-            False,
             ("signed", "commits", "not required"),
             id="required-signature disabled",
-        ),
-        pytest.param(
-            f"test-branch/branch/unsigned-commits/{uuid4()}",
-            BranchWithProtection(required_signatures_enabled=True),
-            True,
-            ("commit", "not signed"),
-            id="required-signature enabled branch has unsigned commits",
         ),
     ],
     indirect=["github_branch", "protected_github_branch"],
 )
 @pytest.mark.usefixtures("protected_github_branch")
 def test_fail(
-    github_repository: Repository,
     github_branch: Branch,
-    add_commit: bool,
     reason_string_array: tuple[str],
     github_repository_name: str,
 ):
@@ -57,11 +46,6 @@ def test_fail(
     act: when branch_protection is called with the name of the branch.
     assert: then a fail report is returned.
     """
-    if add_commit:
-        github_repository.create_file(
-            "test.txt", "testing", "some content", branch=github_branch.name
-        )
-
     # The github_client is injected
     report = branch_protection(  # pylint: disable=no-value-for-parameter
         repository_name=github_repository_name,


### PR DESCRIPTION
Changes the check for `workflow_dispatch` and `push` for whether the commits on a branch are signed to no longer require all commits not on the default branch to be signed. The commit the job is running on is still required to be signed.

The rationale is that there are certain branches, for example those tracking past versions still being maintained, that will never be merged into the default branch and it wouldn't be feasible to go back and sign all the commits. The branch protection for signed commits is still required meaning that any new commits are required to be signed.

Pull request checklist:

- [x] Version has been incremented
