### PR TITLE
add support for schedule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,22 @@
-<description here>
+Applicable spec: <link>
 
-Pull request checklist:
+### Overview
 
+<!-- A high level overview of the change -->
+
+### Rationale
+
+<!-- The reason the change is needed -->
+
+### Module Changes
+
+<!-- Any high level changes to modules and why (Service, Observer, helper) -->
+
+### Checklist
+
+- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
+- [ ] The documentation is generated using `src-docs`
+- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
 - [ ] Version has been incremented
+
+<!-- Explanation for any unchecked items above -->

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ policies:
   `collaborators` and `execute_job`.
 * `workflow_dispatch`: Runs `branch_protection` and `collaborators`.
 * `push`: Runs `branch_protection` and `collaborators`.
+* `schedule`: Runs `branch_protection` and `collaborators`.
 
 These policies are designed for workflow runs in the context of a pull request.
 
 ## Customizing Enabled Policies
 
-Each of `pull_request`, `workflow_dispatch` and `push` accept a
+Each of `pull_request`, `workflow_dispatch`, `schedule` and `push` accept a
 `policy_document` argument which can be used to change which policies are
 enabled. If supplied, it should be a dictionary that complies with the
 [policy JSON schema](repo_policy_compliance/policy_schema.yaml).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.2.0"
+version = "1.3.0"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/repo_policy_compliance/policy.py
+++ b/repo_policy_compliance/policy.py
@@ -19,11 +19,13 @@ class JobType(str, Enum):
         PULL_REQUEST: Policies for pull requests.
         WORKFLOW_DISPATCH: Policies for workflow dispatch jobs.
         PUSH: Policies for push jobs.
+        SCHEDULE: Policies for scheduled jobs.
     """
 
     PULL_REQUEST = "pull_request"
     WORKFLOW_DISPATCH = "workflow_dispatch"
     PUSH = "push"
+    SCHEDULE = "schedule"
 
 
 class PullRequestProperty(str, Enum):
@@ -56,6 +58,7 @@ class BranchJobProperty(str, Enum):
 
 WorkflowDispatchProperty = BranchJobProperty
 PushProperty = BranchJobProperty
+ScheduleProperty = BranchJobProperty
 
 
 # Using MappingProxyType to make these immutable
@@ -66,6 +69,7 @@ ALL = MappingProxyType(
         JobType.PULL_REQUEST: {prop: ENABLED_RULE for prop in PullRequestProperty},
         JobType.WORKFLOW_DISPATCH: {prop: ENABLED_RULE for prop in WorkflowDispatchProperty},
         JobType.PUSH: {prop: ENABLED_RULE for prop in PushProperty},
+        JobType.SCHEDULE: {prop: ENABLED_RULE for prop in ScheduleProperty},
     }
 )
 
@@ -104,7 +108,7 @@ def check(document: dict) -> Report:
 
 def enabled(
     job_type: JobType,
-    name: PullRequestProperty | WorkflowDispatchProperty | PushProperty,
+    name: PullRequestProperty | WorkflowDispatchProperty | PushProperty | ScheduleProperty,
     policy_document: MappingProxyType,
 ) -> bool:
     """Check whether a given policy is enabled.

--- a/repo_policy_compliance/policy_schema.yaml
+++ b/repo_policy_compliance/policy_schema.yaml
@@ -31,6 +31,14 @@ properties:
       collaborators:
         $ref: "#/$defs/rule"
     additionalProperties: false
+  schedule:
+    type: object
+    properties:
+      branch_protection:
+        $ref: "#/$defs/rule"
+      collaborators:
+        $ref: "#/$defs/rule"
+    additionalProperties: false
 additionalProperties: false
 $defs:
   rule:

--- a/tests/integration/test_schedule.py
+++ b/tests/integration/test_schedule.py
@@ -1,0 +1,166 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for the schedule function."""
+
+# These tests are similar to workflow dispatch tests, in tests some duplication is ok to make the
+# tests easier to understand
+# pylint: disable=duplicate-code
+
+from uuid import uuid4
+
+import pytest
+from github.Branch import Branch
+
+from repo_policy_compliance import ScheduleInput, policy, schedule
+from repo_policy_compliance.check import Result
+
+from .types_ import BranchWithProtection, RequestedCollaborator
+
+
+def test_invalid_policy():
+    """
+    arrange: given invalid policy
+    act: when schedule is called with the policy
+    assert: then a fail report is returned.
+    """
+    policy_document = {"invalid": "value"}
+
+    report = schedule(
+        input_=ScheduleInput(
+            repository_name="repository 1",
+            branch_name="branch 1",
+            commit_sha="commit sha 1",
+        ),
+        policy_document=policy_document,
+    )
+
+    assert report.result == Result.FAIL, report.reason
+
+
+@pytest.mark.parametrize(
+    "github_branch, policy_enabled, expected_result",
+    [
+        pytest.param(
+            f"test-branch/schedule/branch-fail-enabled/{uuid4()}",
+            True,
+            Result.FAIL,
+            id="policy enabled",
+        ),
+        pytest.param(
+            f"test-branch/schedule/branch-fail-disabled/{uuid4()}",
+            False,
+            Result.PASS,
+            id="policy disabled",
+        ),
+    ],
+    indirect=["github_branch"],
+)
+def test_branch(
+    github_branch: Branch,
+    policy_enabled: bool,
+    expected_result: Result,
+    github_repository_name: str,
+):
+    """
+    arrange: given a branch that is not compliant and whether the policy is enabled
+    act: when schedule is called with the policy
+    assert: then the expected report is returned.
+    """
+    policy_document = {
+        policy.JobType.SCHEDULE: {
+            policy.ScheduleProperty.BRANCH_PROTECTION: {policy.ENABLED_KEY: policy_enabled}
+        }
+    }
+
+    report = schedule(
+        input_=ScheduleInput(
+            repository_name=github_repository_name,
+            branch_name=github_branch.name,
+            commit_sha="sha 1",
+        ),
+        policy_document=policy_document,
+    )
+
+    assert report.result == expected_result, report.reason
+
+
+@pytest.mark.parametrize(
+    "github_branch, protected_github_branch, collaborators_with_permission, policy_enabled, "
+    "expected_result",
+    [
+        pytest.param(
+            f"test-branch/schedule/collaborators-fail-enabled/{uuid4()}",
+            BranchWithProtection(),
+            RequestedCollaborator("admin", "admin"),
+            True,
+            Result.FAIL,
+            id="policy enabled",
+        ),
+        pytest.param(
+            f"test-branch/schedule/collaborators-fail-disabled/{uuid4()}",
+            BranchWithProtection(),
+            RequestedCollaborator("admin", "admin"),
+            False,
+            Result.PASS,
+            id="policy disabled",
+        ),
+    ],
+    indirect=["github_branch", "protected_github_branch", "collaborators_with_permission"],
+)
+@pytest.mark.usefixtures("protected_github_branch", "collaborators_with_permission")
+def test_collaborators(
+    github_branch: Branch,
+    github_repository_name: str,
+    policy_enabled: bool,
+    expected_result: Result,
+):
+    """
+    arrange: given a branch that are compliant and outside collaborators with more than read
+        permission and whether the policy is enabled
+    act: when schedule is called with the policy
+    assert: then the expected report is returned.
+    """
+    policy_document = {
+        policy.JobType.SCHEDULE: {
+            policy.ScheduleProperty.COLLABORATORS: {policy.ENABLED_KEY: policy_enabled}
+        }
+    }
+
+    report = schedule(
+        input_=ScheduleInput(
+            repository_name=github_repository_name,
+            branch_name=github_branch.name,
+            commit_sha=github_branch.commit.sha,
+        ),
+        policy_document=policy_document,
+    )
+
+    assert report.result == expected_result
+
+
+@pytest.mark.parametrize(
+    "github_branch, protected_github_branch",
+    [pytest.param(f"test-branch/schedule/pass/{uuid4()}", BranchWithProtection())],
+    indirect=True,
+)
+@pytest.mark.usefixtures("protected_github_branch")
+def test_pass(
+    github_branch: Branch, github_repository_name: str, caplog: pytest.LogCaptureFixture
+):
+    """
+    arrange: given a branch and repository that is compliant
+    act: when schedule is called
+    assert: then a pass report is returned.
+    """
+    report = schedule(
+        input_=ScheduleInput(
+            repository_name=github_repository_name,
+            branch_name=github_branch.name,
+            commit_sha=github_branch.commit.sha,
+        ),
+    )
+
+    assert report.result == Result.PASS
+    assert repr("schedule") in caplog.text
+    assert repr(report) in caplog.text

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -34,6 +34,9 @@ from .. import assert_
                 policy.JobType.PUSH: {
                     name: {**policy.ENABLED_RULE} for name in policy.PushProperty
                 },
+                policy.JobType.SCHEDULE: {
+                    name: {**policy.ENABLED_RULE} for name in policy.ScheduleProperty
+                },
             },
             True,
             None,
@@ -60,6 +63,7 @@ from .. import assert_
             zip(repeat(policy.JobType.PULL_REQUEST), policy.PullRequestProperty),
             zip(repeat(policy.JobType.WORKFLOW_DISPATCH), policy.WorkflowDispatchProperty),
             zip(repeat(policy.JobType.PUSH), policy.PushProperty),
+            zip(repeat(policy.JobType.SCHEDULE), policy.ScheduleProperty),
         )
     ]
     + [
@@ -73,6 +77,7 @@ from .. import assert_
             zip(repeat(policy.JobType.PULL_REQUEST), policy.PullRequestProperty),
             zip(repeat(policy.JobType.WORKFLOW_DISPATCH), policy.WorkflowDispatchProperty),
             zip(repeat(policy.JobType.PUSH), policy.PushProperty),
+            zip(repeat(policy.JobType.SCHEDULE), policy.ScheduleProperty),
         )
     ],
 )
@@ -152,7 +157,10 @@ def test_check(document: dict, expected_result: bool, expected_reason: tuple[str
 )
 def test_enabled(
     job_type: policy.JobType,
-    name: policy.PullRequestProperty | policy.WorkflowDispatchProperty | policy.PushProperty,
+    name: policy.PullRequestProperty
+    | policy.WorkflowDispatchProperty
+    | policy.PushProperty
+    | policy.ScheduleProperty,
     document: MappingProxyType,
     expected_result: bool,
 ):


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

Adds support for the on schedlue workflow trigger

### Module Changes

Added a new method and endpoint for adding support for the schedule workflow trigger

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented

`src-docs` to be added in a follow up PR
