### PR TITLE
change to write from maintain

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ policies:
   on must be signed.
 * `collaborators`: Check that all outside collaborators of the project have at
   most `read` permissions.
-* `execute_job`: That a maintainer or above has left the comment
+* `execute_job`: That a user with write permission or above has left the comment
   `/canonical/self-hosted-runners/run-workflows <commit SHA>` approving a
   workflow run for a specific commit SHA. Only applicable to forked source
   branches.
@@ -60,4 +60,4 @@ short lived, e.g., 7 days. If it expires, a new token needs to be set.
 
 On GitHub actions, an expanded set of tests is run as the `GITHUB_TOKEN` for a
 bot is available which can be used to test things like comments from a user that
-is not a maintainer or above.
+does not have write permission or above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.3.0"
+version = "1.4.0"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -323,13 +323,14 @@ def _branch_external_fork(
 ) -> bool:
     """Check whether a branch is an external fork.
 
-    A external fork is a fork that is not owned by a user who is also a maintainer or above on
-    the repository.
+    A external fork is a fork that is not owned by a user who has push or above permission on the
+    repository.
 
     Args:
         repository_name: The name of the repository to run the check on.
         source_repository_name: The name of the repository that contains the source branch.
-        push_logins: The logins from maintainer or above on the repository.
+        push_logins: The logins from users with push or above permission or above on the
+            repository.
 
     Returns:
         Whether the branch is from a external fork.
@@ -337,7 +338,7 @@ def _branch_external_fork(
     if repository_name == source_repository_name:
         return False
 
-    # Check if the owner of the fork is also a maintainer or above on the repo
+    # Check if the owner of the fork also has puish or higher permission
     if source_repository_name.split("/")[0] in push_logins:
         return False
 

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -339,7 +339,7 @@ def _branch_external_fork(
     if repository_name == source_repository_name:
         return False
 
-    # Check if the owner of the fork also has puish or higher permission
+    # Check if the owner of the fork also has push or higher permission
     if source_repository_name.split("/")[0] in push_logins:
         return False
 

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -24,6 +24,7 @@ FAILURE_MESSAGE = (
     "\n"
 )
 AUTHORIZATION_STRING_PREFIX = "/canonical/self-hosted-runners/run-workflows"
+# write permission in the UI is equivalent to push permission on the GitHub API
 EXECUTE_JOB_MESSAGE = (
     "execution not authorized, a comment from a user with write permission or above on the "
     "repository approving the workflow was not found on a PR from a fork, the comment should "
@@ -416,7 +417,8 @@ def execute_job(
             ),
         )
 
-    # Check that the commenter has push or above permissions
+    # Check that the commenter has push or above permissions, this permission is called write in
+    # the UI
     if not any(comment.user.login in push_logins for comment in authorization_comments):
         return Report(
             result=Result.FAIL,

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -88,7 +88,7 @@ def inject(func: Callable[Concatenate[Github, P], R]) -> Callable[P, R]:
 
 def get_collaborators(
     affiliation: Literal["outside", "all"],
-    permission: Literal["triage", "maintain", "admin", "pull"],
+    permission: Literal["triage", "maintain", "admin", "pull", "push"],
     repository: Repository,
 ) -> list[dict]:
     """Get collaborators with a given affiliation and permission.

--- a/src-docs/github_client.py.md
+++ b/src-docs/github_client.py.md
@@ -66,7 +66,7 @@ Injects a GitHub client as the first argument to a function.
 ```python
 get_collaborators(
     affiliation: Literal['outside', 'all'],
-    permission: Literal['triage', 'maintain', 'admin', 'pull'],
+    permission: Literal['triage', 'maintain', 'admin', 'pull', 'push'],
     repository: Repository
 ) → list[dict]
 ```

--- a/tests/integration/test_execute_job.py
+++ b/tests/integration/test_execute_job.py
@@ -238,7 +238,7 @@ def test_fail_forked_comment_from_wrong_user_on_pr(
     ci_github_repository: Repository | None,
 ):
     """
-    arrange: given a fork branch that has a PR with the right comment from a user that does no
+    arrange: given a fork branch that has a PR with the right comment from a user that does not
         have write access
     act: when execute_job is called
     assert: then a fail report is returned.

--- a/tests/integration/test_execute_job.py
+++ b/tests/integration/test_execute_job.py
@@ -29,14 +29,14 @@ from .. import assert_
             "user-1/name-1",
             {"user-1"},
             False,
-            id="repo names don't match, owner in write logins",
+            id="repo names don't match, owner in push logins",
         ),
         pytest.param(
             "repo-1/name-1",
             "user-1/name-1",
             set(),
             True,
-            id="repo names don't match, owner not in write logins",
+            id="repo names don't match, owner not in push logins",
         ),
     ],
 )
@@ -47,8 +47,8 @@ def test__branch_external_fork(
     expected_result: bool,
 ):
     """
-    arrange: given repository name, source repository name and write logins
-    act: when repository name, source repository name and write logins are passed to
+    arrange: given repository name, source repository name and push logins
+    act: when repository name, source repository name and push logins are passed to
         _branch_external_fork
     assert: then the expected result is returned.
     """
@@ -239,7 +239,7 @@ def test_fail_forked_comment_from_wrong_user_on_pr(
 ):
     """
     arrange: given a fork branch that has a PR with the right comment from a user that does not
-        have write access
+        have push access
     act: when execute_job is called
     assert: then a fail report is returned.
     """
@@ -321,7 +321,7 @@ def test_pass_fork(
     ci_github_repository: Repository | None,
 ):
     """
-    arrange: given a fork branch that has a PR with an authorization comment from a user with write
+    arrange: given a fork branch that has a PR with an authorization comment from a user with push
         or above permission
     act: when execute_job is called
     assert: then a pass report is returned.
@@ -355,7 +355,7 @@ def test_pass_fork(
 
 @pytest.mark.parametrize(
     "forked_github_branch",
-    [f"test-branch/execute-job/writer-fork-branch/{uuid4()}"],
+    [f"test-branch/execute-job/push-fork-branch/{uuid4()}"],
     indirect=True,
 )
 def test_pass_fork_collaborator_no_comment(
@@ -365,8 +365,8 @@ def test_pass_fork_collaborator_no_comment(
     commit_on_forked_github_branch: Commit,
 ):
     """
-    arrange: given a fork branch from a writer that has a PR without an authorization comment
-        from a writer
+    arrange: given a fork branch from a push permission user that has a PR without an authorization
+        comment from a push
     act: when execute_job is called
     assert: then a pass report is returned.
     """


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Changes the minimum permission from maintain to write for requiring approval to run code on the self-hosted runners and for being able to approve self-hosted runner runs.

### Rationale

It is already [enforced](https://github.com/canonical/repo-policy-compliance/blob/7e7fea58b7d79a86f0ab5562dc099e1dc825893c/repo_policy_compliance/check.py#L287) that anyone with higher than read permissions on a repository is part of the organisation hosted by that repository, i.e., anyone with write or above permission is a Canonical employee and hence already able to execute arbitrary code on our infrastructure. therefore, there is no change in the security risk model with this change.

### Module Changes

N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented
