### PR TITLE
Remove the dot at the end of the link

### DIFF
--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -18,8 +18,8 @@ from repo_policy_compliance.github_client import inject as inject_github_client
 BYPASS_ALLOWANCES_KEY = "bypass_pull_request_allowances"
 FAILURE_MESSAGE = (
     "\n"
-    "This job has failed to pass a repository policy compliance check as defined in "
-    "https://github.com/canonical/repo-policy-compliance. The specific failure is listed "
+    "This job has failed to pass a repository policy compliance check as defined in the "
+    "https://github.com/canonical/repo-policy-compliance repository. The specific failure is listed "
     "below. Please update the settings on this project to fix the relevant policy."
     "\n"
 )

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -19,7 +19,8 @@ BYPASS_ALLOWANCES_KEY = "bypass_pull_request_allowances"
 FAILURE_MESSAGE = (
     "\n"
     "This job has failed to pass a repository policy compliance check as defined in the "
-    "https://github.com/canonical/repo-policy-compliance repository. The specific failure is listed "
+    "https://github.com/canonical/repo-policy-compliance repository. "
+    "The specific failure is listed "
     "below. Please update the settings on this project to fix the relevant policy."
     "\n"
 )


### PR DESCRIPTION
Applicable spec: N/A

### Overview

When viewing the error in a github CI log, clicking on it resolves to a 404 since github integrates the dot '.' as part of the URL (as seen [here](https://github.com/canonical/discourse-k8s-operator/actions/runs/6332552321/job/17199193563?pr=71#step:2:9)).   
I slightly changed the wording to make it clickable without issue.

### Module Changes

N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] Version has been incremented

I'm not sure that this warrants a version change (does it?)
