### PR TITLE
change commits to be fetched within a month

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.4.0"
+version = "1.4.1"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -3,6 +3,7 @@
 
 """Individual checks used to compose job checks."""
 
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import NamedTuple
 
@@ -112,10 +113,11 @@ def unique_commits_signed(
     Returns:
         Whether the unique commits on the branch are signed.
     """
+    commits_since = datetime.now() - timedelta(days=30)
     other_branch_commit_shas = {
-        commit.sha for commit in repository.get_commits(sha=other_branch_name)
+        commit.sha for commit in repository.get_commits(sha=other_branch_name, since=commits_since)
     }
-    branch_commits = repository.get_commits(sha=branch_name)
+    branch_commits = repository.get_commits(sha=branch_name, since=commits_since)
     unsigned_unique_branch_commits = (
         commit
         for commit in branch_commits


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Change the commits fetched to be only the last month

### Rationale

This is a hotfix with a longer term fix to be added soon

### Module Changes

N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented

<!-- Explanation for any unchecked items above -->
