### PR TITLE
remove requirement for dismissing stale reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ The module exposes several functions to check for compliance with the following
 policies:
 
 * `target_branch_protection`: That the branch targeted by a pull request has
-  protection enabled, stale reviews are dismissed and that rules cannot be
-  bypassed. The requirement for reviews is relaxed for non-default branches
-  where both the source and target branch are on the repository.
+  protection enabled and that rules cannot be bypassed. The requirement for
+  reviews is relaxed for non-default branches where both the source and target
+  branch are on the repository.
 * `collaborators`: Check that all outside collaborators of the project have at
   most `read` permissions.
 * `execute_job`: That a user with write permission or above has left the comment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.6.0"
+version = "1.7.0"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -115,11 +115,6 @@ def target_branch_protection(
                     f"{FAILURE_MESSAGE}pull request reviews are not required, {branch_name=!r}"
                 ),
             )
-        if not pull_request_reviews.dismiss_stale_reviews:
-            return Report(
-                result=Result.FAIL,
-                reason=(f"{FAILURE_MESSAGE}stale reviews are not dismissed, {branch_name=!r}"),
-            )
         # Check for bypass allowances
         bypass_allowances = pull_request_reviews.raw_data.get(BYPASS_ALLOWANCES_KEY, {})
         if any(bypass_allowances.get(key, []) for key in ("users", "teams", "apps")):

--- a/tests/integration/branch_protection.py
+++ b/tests/integration/branch_protection.py
@@ -18,7 +18,6 @@ def edit(branch: Branch, branch_with_protection: BranchWithProtection) -> None:
     """
     if branch_with_protection.bypass_pull_request_allowance_disabled:
         branch.edit_protection(
-            dismiss_stale_reviews=branch_with_protection.dismiss_stale_reviews_enabled,
             # This seems to be required as of version 1.59 of PyGithub, without it the API returns
             # an error indicating that None is not a valid value for bypass pull request
             # allowances. Mypy also seems to be finding the wrong argument name
@@ -28,7 +27,6 @@ def edit(branch: Branch, branch_with_protection: BranchWithProtection) -> None:
         )
     else:
         branch.edit_protection(
-            dismiss_stale_reviews=branch_with_protection.dismiss_stale_reviews_enabled,
             users_bypass_pull_request_allowances=[  # type: ignore
                 "gregory-schiano",
                 "jdkanderson",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -238,10 +238,7 @@ def protected_github_branch_with_commit_in_ci(
 
     # Can't use protected_github_branch since the commit needs to be done before the branch
     # protections are applied
-    branch_with_protection = BranchWithProtection(
-        dismiss_stale_reviews_enabled=False,
-        bypass_pull_request_allowance_disabled=True,
-    )
+    branch_with_protection = BranchWithProtection(bypass_pull_request_allowance_disabled=True)
 
     branch_protection.edit(branch=github_branch, branch_with_protection=branch_with_protection)
 

--- a/tests/integration/test_target_branch_protection.py
+++ b/tests/integration/test_target_branch_protection.py
@@ -26,12 +26,6 @@ from .types_ import BranchWithProtection
             id="branch_protection disabled",
         ),
         pytest.param(
-            f"test-branch/target-branch/stale-review-not-dismissed/{uuid4()}",
-            BranchWithProtection(dismiss_stale_reviews_enabled=False),
-            ("stale", "reviews", "not dismissed"),
-            id="stale-review not-dismissed",
-        ),
-        pytest.param(
             f"test-branch/target-branch/pull-request-allowance-not-empty/{uuid4()}",
             BranchWithProtection(bypass_pull_request_allowance_disabled=False),
             ("pull request", "reviews", "can be bypassed"),
@@ -179,9 +173,7 @@ def test_pass_default_branch(
         (
             f"test-branch/target-branch/protected-on-repo/{uuid4()}",
             BranchWithProtection(
-                branch_protection_enabled=True,
-                dismiss_stale_reviews_enabled=False,
-                bypass_pull_request_allowance_disabled=False,
+                branch_protection_enabled=True, bypass_pull_request_allowance_disabled=False
             ),
         )
     ],

--- a/tests/integration/types_.py
+++ b/tests/integration/types_.py
@@ -13,13 +13,11 @@ class BranchWithProtection:
 
     Attributes:
         branch_protection_enabled: True if we need to enable branch protection enabled.
-        dismiss_stale_reviews_enabled: True if branch dismisses stale reviews.
         bypass_pull_request_allowance_disabled: True if users/teams/apps are allowed to bypass
             pull requests.
     """
 
     branch_protection_enabled: bool = True
-    dismiss_stale_reviews_enabled: bool = True
     bypass_pull_request_allowance_disabled: bool = True
 
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Removes the requirement for dismissing stale reviews because it limits adoption where teams conditionally approve pending trivial fixes such as spelling mistakes

### Rationale

This will widen the adoption of the runners as it fits within the development practices of more teams

### Module Changes

Removes the requirement for stale reviews from the check module

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented

<!-- Explanation for any unchecked items above -->
