### PR TITLE
update licence header

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: Tests

--- a/generate-src-docs.sh
+++ b/generate-src-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 rm -rf src-docs

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [virtualenvs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tool.poetry]

--- a/repo_policy_compliance/__init__.py
+++ b/repo_policy_compliance/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Library for checking that GitHub repos comply with policy."""

--- a/repo_policy_compliance/blueprint.py
+++ b/repo_policy_compliance/blueprint.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Provides API blueprint for flask to run the policy checks.

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Individual checks used to compose job checks."""

--- a/repo_policy_compliance/comment.py
+++ b/repo_policy_compliance/comment.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for modifying comments."""

--- a/repo_policy_compliance/exceptions.py
+++ b/repo_policy_compliance/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """All the exceptions that can be raised."""

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for GitHub client."""

--- a/repo_policy_compliance/log.py
+++ b/repo_policy_compliance/log.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for logging."""

--- a/repo_policy_compliance/policy.py
+++ b/repo_policy_compliance/policy.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Module for the policy document."""

--- a/repo_policy_compliance/policy_schema.yaml
+++ b/repo_policy_compliance/policy_schema.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 type: object

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for checking that GitHub repos comply with policy."""

--- a/tests/assert_.py
+++ b/tests/assert_.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Functions that help with asserting."""

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Integration tests for checking that GitHub repos comply with policy."""

--- a/tests/integration/branch_protection.py
+++ b/tests/integration/branch_protection.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Functions that help with branch protection."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Fixtures for integration tests."""

--- a/tests/integration/test_blueprint.py
+++ b/tests/integration/test_blueprint.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the flask blueprint."""

--- a/tests/integration/test_collaborators.py
+++ b/tests/integration/test_collaborators.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the collaborators function."""

--- a/tests/integration/test_execute_job.py
+++ b/tests/integration/test_execute_job.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the execute_job function."""

--- a/tests/integration/test_github_client.py
+++ b/tests/integration/test_github_client.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the github_client module."""

--- a/tests/integration/test_pull_request.py
+++ b/tests/integration/test_pull_request.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the pull_request function."""

--- a/tests/integration/test_push.py
+++ b/tests/integration/test_push.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the push function."""

--- a/tests/integration/test_schedule.py
+++ b/tests/integration/test_schedule.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the schedule function."""

--- a/tests/integration/test_target_branch_protection.py
+++ b/tests/integration/test_target_branch_protection.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the target_branch_protection function."""

--- a/tests/integration/test_workflow_dispatch.py
+++ b/tests/integration/test_workflow_dispatch.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the workflow_dispatch function."""

--- a/tests/integration/types_.py
+++ b/tests/integration/types_.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Shared types for testing."""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Unit tests for checking that GitHub repos comply with policy."""

--- a/tests/unit/test_comment.py
+++ b/tests/unit/test_comment.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the comment module."""

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the github_client function."""

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Tests for the policy module."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fixes the licence header

### Rationale

Since the year is now 2024

### Module Changes

N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] Version has been incremented

No changes so no need to increment version
