### PR TITLE
fix: check directly for user permission

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,6 @@ Applicable spec: <link>
 - [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
 - [ ] The documentation is generated using `src-docs`
 - [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
-- [ ] Version has been incremented
+- [ ] Version has been incremented on `pyproject.toml`
 
 <!-- Explanation for any unchecked items above -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.7.0"
+version = "1.7.1"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -188,7 +188,6 @@ def _branch_external_fork(repository: Repository, source_repository_name: str) -
     fork_username = source_repository_name.split("/")[0]
 
     # Check if owner of the fork already has push or higher permission (not an external user)
-    # This additional check is a fail-safe to paginated results of push_logins.
     fork_user_permission = get_collaborator_permission(repository, fork_username)
     if fork_user_permission in ("admin", "write"):
         return False

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -8,10 +8,15 @@ from typing import NamedTuple
 
 from github import Github
 from github.Branch import Branch
+from github.Repository import Repository
 
 from repo_policy_compliance import log
 from repo_policy_compliance.comment import remove_quote_lines
-from repo_policy_compliance.github_client import get_branch, get_collaborators
+from repo_policy_compliance.github_client import (
+    get_branch,
+    get_collaborator_permission,
+    get_collaborators,
+)
 from repo_policy_compliance.github_client import inject as inject_github_client
 
 BYPASS_ALLOWANCES_KEY = "bypass_pull_request_allowances"
@@ -164,28 +169,28 @@ def collaborators(github_client: Github, repository_name: str) -> Report:
     return Report(result=Result.PASS, reason=None)
 
 
-def _branch_external_fork(
-    repository_name: str, source_repository_name: str, push_logins: set[str]
-) -> bool:
+def _branch_external_fork(repository: Repository, source_repository_name: str) -> bool:
     """Check whether a branch is an external fork.
 
     A external fork is a fork that is not owned by a user who has push or above permission on the
     repository.
 
     Args:
-        repository_name: The name of the repository to run the check on.
+        repository: The repository to run the check on.
         source_repository_name: The name of the repository that contains the source branch.
-        push_logins: The logins from users with push or above permission or above on the
-            repository.
 
     Returns:
         Whether the branch is from a external fork.
     """
-    if repository_name == source_repository_name:
+    if repository.full_name == source_repository_name:
         return False
 
-    # Check if the owner of the fork also has push or higher permission
-    if source_repository_name.split("/")[0] in push_logins:
+    fork_username = source_repository_name.split("/")[0]
+
+    # Check if owner of the fork already has push or higher permission (not an external user)
+    # This additional check is a fail-safe to paginated results of push_logins.
+    fork_user_permission = get_collaborator_permission(repository, fork_username)
+    if fork_user_permission in ("admin", "write"):
         return False
 
     return True
@@ -220,9 +225,7 @@ def execute_job(
         )
     }
     if not _branch_external_fork(
-        repository_name=repository_name,
-        source_repository_name=source_repository_name,
-        push_logins=push_logins,
+        repository=repository, source_repository_name=source_repository_name
     ):
         return Report(result=Result.PASS, reason=None)
 

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -157,4 +157,4 @@ def get_collaborator_permission(
             f"Invalid collaborator permission {user_permission} received, "
             'expected one of "admin", "write", "read", "none"'
         )
-    return user_permission
+    return cast(Literal["admin", "write", "read", "none"], user_permission)

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -5,7 +5,7 @@
 
 import functools
 import os
-from typing import Callable, Concatenate, Literal, ParamSpec, TypeVar
+from typing import Callable, Concatenate, Literal, ParamSpec, TypeVar, cast
 from urllib import parse
 
 from github import BadCredentialsException, Github, GithubException, RateLimitExceededException
@@ -103,7 +103,12 @@ def get_collaborators(
     """
     collaborators_url = repository.collaborators_url.replace("{/collaborator}", "")
     default_query = dict(parse.parse_qsl(parse.urlparse(collaborators_url).query))
-    query: dict[str, str] = {**default_query, "permission": permission, "affiliation": affiliation}
+    query: dict[str, str] = {
+        **default_query,
+        "permission": permission,
+        "affiliation": affiliation,
+        "per_page": "100",
+    }
 
     # mypy thinks the attribute doesn't exist when it actually does exist
     # need to use requester to send a raw API request
@@ -129,3 +134,20 @@ def get_branch(github_client: Github, repository_name: str, branch_name: str) ->
     """
     repository = github_client.get_repo(repository_name)
     return repository.get_branch(branch_name)
+
+
+def get_collaborator_permission(
+    repository: Repository, username: str
+) -> Literal["admin", "write", "read", "none"]:
+    """Get user permission for a given repository.
+
+    Args:
+        repository: The repository to get collaborators for.
+        username: The github login to check for permission.
+
+    Returns:
+        The collaborator permission.
+    """
+    return cast(
+        Literal["admin", "write", "read", "none"], repository.get_collaborator_permission(username)
+    )

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -145,6 +145,9 @@ def get_collaborator_permission(
         repository: The repository to get collaborators for.
         username: The github login to check for permission.
 
+    Raises:
+        GithubClientError: if an invalid user permission is returned from the API call.
+
     Returns:
         The collaborator permission.
     """

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -148,6 +148,10 @@ def get_collaborator_permission(
     Returns:
         The collaborator permission.
     """
-    return cast(
-        Literal["admin", "write", "read", "none"], repository.get_collaborator_permission(username)
-    )
+    user_permission = repository.get_collaborator_permission(username)
+    if user_permission not in ("admin", "write", "read", "none"):
+        raise GithubClientError(
+            f"Invalid collaborator permission {user_permission} received, "
+            'expected one of "admin", "write", "read", "none"'
+        )
+    return user_permission

--- a/src-docs/__init__.py.md
+++ b/src-docs/__init__.py.md
@@ -21,17 +21,6 @@ Input arguments to check jobs running on a branch.
 
 ---
 
-#### <kbd>property</kbd> model_computed_fields
-
-Get the computed fields of this model instance. 
-
-
-
-**Returns:**
-  A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects. 
-
----
-
 #### <kbd>property</kbd> model_extra
 
 Get extra fields set during validation. 
@@ -73,17 +62,6 @@ Input arguments for pull request checks.
 
 ---
 
-#### <kbd>property</kbd> model_computed_fields
-
-Get the computed fields of this model instance. 
-
-
-
-**Returns:**
-  A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects. 
-
----
-
 #### <kbd>property</kbd> model_extra
 
 Get extra fields set during validation. 
@@ -121,17 +99,6 @@ Input arguments to check jobs running on a branch.
 
 ---
 
-#### <kbd>property</kbd> model_computed_fields
-
-Get the computed fields of this model instance. 
-
-
-
-**Returns:**
-  A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects. 
-
----
-
 #### <kbd>property</kbd> model_extra
 
 Get extra fields set during validation. 
@@ -166,17 +133,6 @@ Input arguments to check jobs running on a branch.
  
  - <b>`repository_name`</b>:  The name of the repository to run the check on. 
 
-
----
-
-#### <kbd>property</kbd> model_computed_fields
-
-Get the computed fields of this model instance. 
-
-
-
-**Returns:**
-  A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects. 
 
 ---
 
@@ -229,17 +185,6 @@ Input arguments to check jobs running on a branch.
  
  - <b>`repository_name`</b>:  The name of the repository to run the check on. 
 
-
----
-
-#### <kbd>property</kbd> model_computed_fields
-
-Get the computed fields of this model instance. 
-
-
-
-**Returns:**
-  A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects. 
 
 ---
 

--- a/src-docs/github_client.py.md
+++ b/src-docs/github_client.py.md
@@ -89,7 +89,7 @@ Get collaborators with a given affiliation and permission.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L124"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_branch`
 
@@ -115,5 +115,33 @@ Get the branch for the check.
 
 **Returns:**
  The requested branch. 
+
+
+---
+
+<a href="../repo_policy_compliance/github_client.py#L139"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `get_collaborator_permission`
+
+```python
+get_collaborator_permission(
+    repository: Repository,
+    username: str
+) → Literal['admin', 'write', 'read', 'none']
+```
+
+Get user permission for a given repository. 
+
+
+
+**Args:**
+ 
+ - <b>`repository`</b>:  The repository to get collaborators for. 
+ - <b>`username`</b>:  The github login to check for permission. 
+
+
+
+**Returns:**
+ The collaborator permission. 
 
 

--- a/src-docs/github_client.py.md
+++ b/src-docs/github_client.py.md
@@ -141,6 +141,12 @@ Get user permission for a given repository.
 
 
 
+**Raises:**
+ 
+ - <b>`GithubClientError`</b>:  if an invalid user permission is returned from the API call. 
+
+
+
 **Returns:**
  The collaborator permission. 
 

--- a/tests/integration/test_execute_job.py
+++ b/tests/integration/test_execute_job.py
@@ -4,7 +4,7 @@
 """Tests for the execute_job function."""
 
 # The tests in this file have to rely on many fixtures, need access to private function to test it
-# pylint: disable=too-many-arguments,protected-access
+# pylint: disable=too-many-arguments
 
 from uuid import uuid4
 
@@ -18,47 +18,6 @@ import repo_policy_compliance
 from repo_policy_compliance.check import AUTHORIZATION_STRING_PREFIX, Result, execute_job
 
 from .. import assert_
-
-
-@pytest.mark.parametrize(
-    "repository_name, source_repository_name, push_logins, expected_result",
-    [
-        pytest.param("repo-1/name-1", "repo-1/name-1", set(), False, id="repo names match"),
-        pytest.param(
-            "repo-1/name-1",
-            "user-1/name-1",
-            {"user-1"},
-            False,
-            id="repo names don't match, owner in push logins",
-        ),
-        pytest.param(
-            "repo-1/name-1",
-            "user-1/name-1",
-            set(),
-            True,
-            id="repo names don't match, owner not in push logins",
-        ),
-    ],
-)
-def test__branch_external_fork(
-    repository_name: str,
-    source_repository_name: str,
-    push_logins: set[str],
-    expected_result: bool,
-):
-    """
-    arrange: given repository name, source repository name and push logins
-    act: when repository name, source repository name and push logins are passed to
-        _branch_external_fork
-    assert: then the expected result is returned.
-    """
-    returned_result = repo_policy_compliance.check._branch_external_fork(
-        repository_name=repository_name,
-        source_repository_name=source_repository_name,
-        push_logins=push_logins,
-    )
-
-    assert returned_result == expected_result
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,0 +1,4 @@
+pydantic>=1,<2
+PyGithub>=2,<3
+PyYAML>=6,<7
+jsonschema>=4,<5

--- a/tests/unit/test_check.py
+++ b/tests/unit/test_check.py
@@ -1,0 +1,76 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for the check module."""
+
+# internal functions are being accessed for testing.
+# pylint: disable=protected-access
+
+from unittest.mock import MagicMock
+
+import pytest
+from github.Repository import Repository
+
+import repo_policy_compliance
+
+
+@pytest.mark.parametrize(
+    "repository_name, source_repository_name, expected_user_permission, expected_result",
+    [
+        pytest.param("repo-1/name-1", "repo-1/name-1", "none", False, id="repo names match"),
+        pytest.param(
+            "repo-1/name-1",
+            "user-1/name-1",
+            "none",
+            True,
+            id="repo names don't match, o owner none permission",
+        ),
+        pytest.param(
+            "repo-1/name-1",
+            "user-1/name-1",
+            "read",
+            True,
+            id="repo names don't match, owner read permission",
+        ),
+        pytest.param(
+            "repo-1/name-1",
+            "user-1/name-1",
+            "write",
+            False,
+            id="repo names don't match, owner write permissions",
+        ),
+        pytest.param(
+            "repo-1/name-1",
+            "user-1/name-1",
+            "admin",
+            False,
+            id="repo names don't match, owner admin permissions",
+        ),
+    ],
+)
+def test__branch_external_fork(
+    monkeypatch: pytest.MonkeyPatch,
+    repository_name: str,
+    source_repository_name: str,
+    expected_user_permission: str,
+    expected_result: bool,
+):
+    """
+    arrange: given repository name, source repository name and push logins
+    act: when repository name, source repository name and push logins are passed to
+        _branch_external_fork
+    assert: then the expected result is returned.
+    """
+    mocked_repository = MagicMock(spec=Repository)
+    mocked_repository.full_name = repository_name
+    monkeypatch.setattr(
+        repo_policy_compliance.check,
+        "get_collaborator_permission",
+        lambda *_args, **_kwargs: expected_user_permission,
+    )
+
+    returned_result = repo_policy_compliance.check._branch_external_fork(
+        repository=mocked_repository, source_repository_name=source_repository_name
+    )
+
+    assert returned_result == expected_result

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from github import Github, GithubException, RateLimitExceededException
 
+import repo_policy_compliance.github_client
 from repo_policy_compliance.check import target_branch_protection
 from repo_policy_compliance.exceptions import GithubClientError
 
@@ -41,6 +42,9 @@ def test_github_error(
 
     monkeypatch.setattr(
         "repo_policy_compliance.github_client.Github", lambda *_args, **_kwargs: github_client
+    )
+    monkeypatch.setattr(
+        repo_policy_compliance.github_client, "get", lambda *_args, **_kwargs: github_client
     )
 
     with pytest.raises(GithubClientError) as error:

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from github import Github, GithubException, RateLimitExceededException
+from github.Repository import Repository
 
 import repo_policy_compliance.github_client
 from repo_policy_compliance.check import target_branch_protection
@@ -53,3 +54,20 @@ def test_github_error(
             GITHUB_REPOSITORY_NAME, GITHUB_BRANCH_NAME, GITHUB_REPOSITORY_NAME
         )
     assert expected_message in str(error.value)
+
+
+def test_get_collaborator_permission_error():
+    """
+    arrange: Given a mocked get_collaborator_permission function that returns invalid value.
+    act: when get_collaborator_permission is called.
+    assert: GithubClientError is raised.
+    """
+    mock_repository = MagicMock(spec=Repository)
+    mock_repository.get_collaborator_permission.return_value = "invalid"
+
+    with pytest.raises(GithubClientError) as error:
+        # The github_client is injected
+        repo_policy_compliance.github_client.get_collaborator_permission(  # pylint: disable=no-value-for-parameter
+            mock_repository, "test_user"
+        )
+    assert "Invalid collaborator permission" in str(error.value)

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -155,10 +155,12 @@ def test_check(document: dict, expected_result: bool, expected_reason: tuple[str
 )
 def test_enabled(
     job_type: policy.JobType,
-    name: policy.PullRequestProperty
-    | policy.WorkflowDispatchProperty
-    | policy.PushProperty
-    | policy.ScheduleProperty,
+    name: (
+        policy.PullRequestProperty
+        | policy.WorkflowDispatchProperty
+        | policy.PushProperty
+        | policy.ScheduleProperty
+    ),
     document: MappingProxyType,
     expected_result: bool,
 ):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, static
+envlist = lint, static, unit
 
 [vars]
 src_path = {toxinidir}/repo_policy_compliance/
@@ -90,6 +90,17 @@ deps =
     bandit[toml]
 commands =
     bandit -c {toxinidir}/pyproject.toml -r {[vars]src_path} {[vars]tst_path}
+
+[testenv:unit]
+description = Run unit tests
+deps =
+    pytest
+    requests-mock
+    coverage[toml]
+    -r{[vars]tst_path}unit/requirements.txt
+commands =
+    coverage run --source={[vars]src_path} \
+        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
 
 [testenv:src-docs]
 allowlist_externals=sh


### PR DESCRIPTION
Applicable spec: N/A

### Overview

The paginated results for GitHub API get_collaborators caused an issue #923 where a user in the team with access to the repository wasn't able to run CI via the forked branch. This change:
1. Adds query parameter of 100 users(current API max) as sensible default for number of users that has access to the repository
2. Directly queries for user permission for the given repository.

### Rationale

Fixes #923, where a user with access rights to a repository was not able to run CI from forks.

### Module Changes

- `check.py:_branch_external_fork` - now queries user permissions directly.
- `github_client.py:get_collaborators` - now queries for 100 (max) users by default.
- `github_client.py:get_collaborator_permission` - added a new function to query for a given user's permission to a target repository.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented

<!-- Explanation for any unchecked items above -->
