### PR TITLE
Ignore test branches for auto-approval workflow

### DIFF
--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -2,6 +2,8 @@ name: Provide approval for bot PRs
 
 on:
   pull_request:
+    branches-ignore:
+      - '**test-branch/**'
 
 jobs:
   bot_pr_approval:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.8.0"
+version = "1.8.1"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,7 +3,7 @@
 
 name: repo-policy-compliance
 base: ubuntu@22.04
-version: '1.8.0'
+version: '1.8.1'
 summary: Check the repository setup for policy compliance
 description: |
     Used to check whether a GitHub repository complies with expected policies.

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -100,7 +100,7 @@ def _simple_retry(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         try:
             return func(*args, **kwargs)
         except GithubException:
-            sleep(max(10 + i * 10, 60))
+            sleep(min(10 + i * 10, 60))
     assert False, f"timed out while waiting for func {func.__name__} to complete"
 
 

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -96,11 +96,11 @@ def _simple_retry(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     Returns:
         The result of the function.
     """
-    for _ in range(10):
+    for i in range(10):
         try:
             return func(*args, **kwargs)
         except GithubException:
-            sleep(10)
+            sleep(max(10 + i * 10, 60))
     assert False, f"timed out while waiting for func {func.__name__} to complete"
 
 


### PR DESCRIPTION
### Overview

Ignore test branches (created by integration tests) for the  approval bot PRs .

Also fix integration testing issues (since switch to gh hosted runners).

### Rationale

These runs are unnecessary.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented on `pyproject.toml`

<!-- Explanation for any unchecked items above -->
