### PR TITLE
Remove the `charm-directory` parameter from the `publish_charm` workflow

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -12,5 +12,4 @@ jobs:
     secrets: inherit
     with:
       channel: latest/edge
-      charm-directory: charm
       charmcraft-channel: "latest/edge"


### PR DESCRIPTION
Remove the `charm-directory` parameter from the `publish_charm` workflow since the `charm-directory` input is deprecated in the new publish workflow.