### PR TITLE
Add resource-mapping to publish_charm.yaml

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -13,3 +13,4 @@ jobs:
     with:
       channel: latest/edge
       charmcraft-channel: "latest/edge"
+      resource-mapping: '{"repo-policy-compliance": "flask-app-image"}'


### PR DESCRIPTION
As this is a PaaS app charm, the resource name (`flask-app-image`) doesn't match the rock name (`repo-policy-compliance`). Add `resource-mapping` to the publishing workflow to map the rock name to the correct resource name.