### PR TITLE
Remove retry on rate limit.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.8.2"
+version = "1.8.3"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -12,7 +12,9 @@ from urllib import parse
 from github import BadCredentialsException, Github, GithubException, RateLimitExceededException
 from github.Auth import Token
 from github.Branch import Branch
+from github.GithubRetry import GithubRetry
 from github.Repository import Repository
+
 
 from repo_policy_compliance.exceptions import (
     ConfigurationError,
@@ -42,7 +44,7 @@ def get() -> Github:
             f"The {GITHUB_TOKEN_ENV_NAME} environment variable was not provided or empty, "
             f"it is needed for interactions with GitHub, got: {github_token!r}"
         )
-    return Github(auth=Token(github_token))
+    return Github(auth=Token(github_token), retry=None)
 
 
 def inject(func: Callable[Concatenate[Github, P], R]) -> Callable[P, R]:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,7 +3,7 @@
 
 name: repo-policy-compliance
 base: ubuntu@22.04
-version: '1.8.2'
+version: '1.8.3'
 summary: Check the repository setup for policy compliance
 description: |
     Used to check whether a GitHub repository complies with expected policies.

--- a/src-docs/github_client.py.md
+++ b/src-docs/github_client.py.md
@@ -11,7 +11,7 @@ Module for GitHub client.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get`
 
@@ -35,7 +35,7 @@ Get a GitHub client.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L58"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `inject`
 
@@ -59,7 +59,7 @@ Injects a GitHub client as the first argument to a function.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L98"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L108"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_collaborators`
 
@@ -89,7 +89,7 @@ Get collaborators with a given affiliation and permission.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L133"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_branch`
 
@@ -119,7 +119,7 @@ Get the branch for the check.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L148"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L158"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_collaborator_permission`
 


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Remove retry on rate limit and only retry once on 5xx http status code.

### Rationale

This should fix #1690 , because there will no longer be connection timeouts on the client side and there will be a proper error msg due to https://github.com/canonical/repo-policy-compliance/blob/main/repo_policy_compliance/check.py#L104-L109.



### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented on `pyproject.toml`

<!-- Explanation for any unchecked items above -->
