### PR TITLE
Catch 404 errors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,6 @@ Applicable spec: <link>
 - [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
 - [ ] The documentation is generated using `src-docs`
 - [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
-- [ ] Version has been incremented on `pyproject.toml`
+- [ ] Version has been incremented on `pyproject.toml` and `rockcraft.yaml`
 
 <!-- Explanation for any unchecked items above -->

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,3 +21,5 @@ jobs:
       charmcraft-channel: latest/edge
       test-tox-env: charm-integration-test
       trivy-image-config: "trivy.yaml"
+      modules: '["test_target_branch_protection"]'  # TODO: speed up by running only one test, remove this line before merging
+

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,5 +21,3 @@ jobs:
       charmcraft-channel: latest/edge
       test-tox-env: charm-integration-test
       trivy-image-config: "trivy.yaml"
-      modules: '["test_target_branch_protection"]'  # TODO: speed up by running only one test, remove this line before merging
-

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      juju-channel: 3.1/stable
+      juju-channel: 3.4/stable
       channel: 1.28-strict/stable
       self-hosted-runner: true
       self-hosted-runner-label: "edge"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.9.0"
+version = "1.9.1"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -218,9 +218,9 @@ def target_branch_protection(
     return Report(result=Result.PASS, reason=None)
 
 
+@log.call
 @github_exceptions_to_fail_report
 @inject_github_client
-@log.call
 def collaborators(github_client: Github, repository_name: str) -> Report:
     """Check that no outside contributors have higher access than read.
 
@@ -272,9 +272,9 @@ class JobMetadata:
     fork_or_branch_repository_name: str
 
 
+@log.call
 @github_exceptions_to_fail_report
 @inject_github_client
-@log.call
 def execute_job(github_client: Github, job_metadata: JobMetadata) -> Report:
     """Check that the execution of the workflow for a SHA has been granted for a PR from a fork.
 
@@ -394,9 +394,9 @@ def _check_authorization_comment(
     return Report(result=Result.PASS, reason=None)
 
 
+@log.call
 @github_exceptions_to_fail_report
 @inject_github_client
-@log.call
 def pull_request_disallow_fork(github_client: Github, job_metadata: JobMetadata) -> Report:
     """Check that the pull request from 3rd party is disallowed.
 

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -113,7 +113,8 @@ def github_exceptions_to_fail_report(func: Callable[P, R]) -> Callable[P, R | Re
             return Report(
                 result=Result.FAIL,
                 reason=f"The repository is not set up correctly. "
-                f"A particular GitHub resource could not be found. The API returned: {exc} ",
+                f"A particular GitHub resource could not be found. "
+                f"{('The API returned:' + exc.api_message) if exc.api_message else ''} ",
             )
         except GithubClientError:
             return Report(

--- a/repo_policy_compliance/check.py
+++ b/repo_policy_compliance/check.py
@@ -150,9 +150,9 @@ def branch_protected(branch: Branch) -> Report:
     return Report(result=Result.PASS, reason=None)
 
 
+@log.call
 @github_exceptions_to_fail_report
 @inject_github_client
-@log.call
 def target_branch_protection(
     github_client: Github, repository_name: str, branch_name: str, source_repository_name: str
 ) -> Report:

--- a/repo_policy_compliance/exceptions.py
+++ b/repo_policy_compliance/exceptions.py
@@ -23,6 +23,14 @@ class GithubClientError(BaseError):
 class GithubApiNotFoundError(GithubClientError):
     """Error occurred on Github API that the resource is not found."""
 
+    def __init__(self, api_message: str | None = None):
+        """Initialize the exception.
+
+        Args:
+            api_message: The message from the Github API. Should be something with "not found".
+        """
+        self.api_message = api_message
+
 
 class RetryableGithubClientError(GithubClientError):
     """Error occurred on Github API that can be retried on user's end."""

--- a/repo_policy_compliance/exceptions.py
+++ b/repo_policy_compliance/exceptions.py
@@ -20,5 +20,9 @@ class GithubClientError(BaseError):
     """Error occurred on Github API."""
 
 
+class GithubApiNotFoundError(GithubClientError):
+    """Error occurred on Github API that the resource is not found."""
+
+
 class RetryableGithubClientError(GithubClientError):
     """Error occurred on Github API that can be retried on user's end."""

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -102,7 +102,7 @@ def inject(func: Callable[Concatenate[Github, P], R]) -> Callable[P, R]:
             ) from exc
         except GithubException as exc:
             if exc.status == 404:
-                raise GithubApiNotFoundError(exc.message) from exc
+                raise GithubApiNotFoundError(exc.data.get("message", "")) from exc
             logging.error("Github client error: %s", exc, exc_info=exc)
             raise GithubClientError("The github client encountered an error.") from exc
 

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -9,13 +9,7 @@ import os
 from typing import Callable, Concatenate, Literal, ParamSpec, TypeVar, cast
 from urllib import parse
 
-from github import (
-    BadCredentialsException,
-    Github,
-    GithubException,
-    RateLimitExceededException,
-    UnknownObjectException,
-)
+from github import BadCredentialsException, Github, GithubException, RateLimitExceededException
 from github.Auth import Token
 from github.Branch import Branch
 from github.Repository import Repository
@@ -106,9 +100,9 @@ def inject(func: Callable[Concatenate[Github, P], R]) -> Callable[P, R]:
                 "The github client is returning a Rate Limit Exceeded error, "
                 "please wait before retrying."
             ) from exc
-        except UnknownObjectException as exc:
-            raise GithubApiNotFoundError(exc.message) from exc
         except GithubException as exc:
+            if exc.status == 404:
+                raise GithubApiNotFoundError(exc.message) from exc
             logging.error("Github client error: %s", exc, exc_info=exc)
             raise GithubClientError("The github client encountered an error.") from exc
 

--- a/repo_policy_compliance/github_client.py
+++ b/repo_policy_compliance/github_client.py
@@ -102,7 +102,7 @@ def inject(func: Callable[Concatenate[Github, P], R]) -> Callable[P, R]:
             ) from exc
         except GithubException as exc:
             if exc.status == 404:
-                raise GithubApiNotFoundError(exc.data.get("message", "")) from exc
+                raise GithubApiNotFoundError(api_message=exc.data.get("message")) from exc
             logging.error("Github client error: %s", exc, exc_info=exc)
             raise GithubClientError("The github client encountered an error.") from exc
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,7 +3,7 @@
 
 name: repo-policy-compliance
 base: ubuntu@22.04
-version: '1.9.0'
+version: '1.9.1'
 summary: Check the repository setup for policy compliance
 description: |
     Used to check whether a GitHub repository complies with expected policies.

--- a/src-docs/check.py.md
+++ b/src-docs/check.py.md
@@ -14,7 +14,7 @@ Individual checks used to compose job checks.
 
 ---
 
-<a href="../repo_policy_compliance/check.py#L81"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/check.py#L82"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `github_exceptions_to_fail_report`
 

--- a/src-docs/exceptions.py.md
+++ b/src-docs/exceptions.py.md
@@ -27,6 +27,15 @@ There is a problem with configuration.
 
 ---
 
+## <kbd>class</kbd> `GithubApiNotFoundError`
+Error occurred on Github API that the resource is not found. 
+
+
+
+
+
+---
+
 ## <kbd>class</kbd> `GithubClientError`
 Error occurred on Github API. 
 

--- a/src-docs/exceptions.py.md
+++ b/src-docs/exceptions.py.md
@@ -30,6 +30,22 @@ There is a problem with configuration.
 ## <kbd>class</kbd> `GithubApiNotFoundError`
 Error occurred on Github API that the resource is not found. 
 
+<a href="../repo_policy_compliance/exceptions.py#L26"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(api_message: str | None = None)
+```
+
+Initialize the exception. 
+
+
+
+**Args:**
+ 
+ - <b>`api_message`</b>:  The message from the Github API. Should be something with "not found". 
+
 
 
 

--- a/src-docs/github_client.py.md
+++ b/src-docs/github_client.py.md
@@ -11,7 +11,7 @@ Module for GitHub client.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get`
 
@@ -35,7 +35,7 @@ Get a GitHub client.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L58"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L65"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `inject`
 
@@ -59,7 +59,7 @@ Injects a GitHub client as the first argument to a function.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L108"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L118"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_collaborators`
 
@@ -89,7 +89,7 @@ Get collaborators with a given affiliation and permission.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L153"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_branch`
 
@@ -119,7 +119,7 @@ Get the branch for the check.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L158"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L168"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_collaborator_permission`
 

--- a/src-docs/github_client.py.md
+++ b/src-docs/github_client.py.md
@@ -11,7 +11,7 @@ Module for GitHub client.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get`
 
@@ -35,7 +35,7 @@ Get a GitHub client.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L65"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L59"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `inject`
 
@@ -59,7 +59,7 @@ Injects a GitHub client as the first argument to a function.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L118"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L112"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_collaborators`
 
@@ -89,7 +89,7 @@ Get collaborators with a given affiliation and permission.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L153"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L147"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_branch`
 
@@ -119,7 +119,7 @@ Get the branch for the check.
 
 ---
 
-<a href="../repo_policy_compliance/github_client.py#L168"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repo_policy_compliance/github_client.py#L162"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_collaborator_permission`
 

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -215,6 +215,7 @@ def fixture_ruleset_protected_github_branch(
         "conditions": {
             "ref_name": {
                 "include": [f"refs/heads/{github_branch.name}"],
+                "exclude": ["refs/heads/dev*"],
             }
         },
     }

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -202,9 +202,7 @@ def fixture_ruleset_protected_github_branch(
 ) -> Iterator[Branch]:
     """Add ruleset protection for a branch."""
     github_token = os.getenv(GITHUB_TOKEN_ENV_NAME) or os.getenv(f"FLASK_{GITHUB_TOKEN_ENV_NAME}")
-    url = (
-        f"https://api.github.com/repos/{github_repository.owner}/{github_repository.name}/rulesets"
-    )
+    url = f"https://api.github.com/repos/{github_repository.full_name}/rulesets"
     headers = {
         "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {github_token}",
@@ -229,10 +227,7 @@ def fixture_ruleset_protected_github_branch(
 
     # delete the ruleset
     ruleset_id = response.json()["id"]
-    url = (
-        f"https://api.github.com/repos/{github_repository.owner}/{github_repository.name}/"
-        f"rulesets/{ruleset_id}"
-    )
+    url = f"https://api.github.com/repos/{github_repository.full_name}/rulesets/{ruleset_id}"
     response = requests.delete(url, headers=headers, timeout=10)
     response.raise_for_status()
 

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -215,9 +215,10 @@ def fixture_ruleset_protected_github_branch(
         "conditions": {
             "ref_name": {
                 "include": [f"refs/heads/{github_branch.name}"],
-                "exclude": ["refs/heads/dev*"],
+                "exclude": [],
             }
         },
+        "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
     }
 
     response = requests.post(url, headers=headers, json=data, timeout=10)

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -30,6 +30,14 @@ def fixture_github_repository_name(pytestconfig: pytest.Config) -> str:
     return pytestconfig.getoption(REPOSITORY_ARGUMENT_NAME)
 
 
+@pytest.fixture(scope="session", name="github_token")
+def fixutre_github_token() -> str:
+    """Get the GitHub token from the environment."""
+    github_token = os.getenv(GITHUB_TOKEN_ENV_NAME)
+    assert github_token, f"GitHub must be set in the environment variable {GITHUB_TOKEN_ENV_NAME}"
+    return github_token
+
+
 @pytest.fixture(scope="session", name="ci_github_token")
 def fixture_ci_github_token() -> str | None:
     """Get the GitHub token from the CI environment."""
@@ -198,10 +206,9 @@ def fixture_protected_github_branch(
 
 @pytest.fixture(name="ruleset_protected_github_branch")
 def fixture_ruleset_protected_github_branch(
-    github_branch: Branch, github_repository: Repository
+    github_token: str, github_branch: Branch, github_repository: Repository
 ) -> Iterator[Branch]:
     """Add ruleset protection for a branch."""
-    github_token = os.getenv(GITHUB_TOKEN_ENV_NAME) or os.getenv(f"FLASK_{GITHUB_TOKEN_ENV_NAME}")
     url = f"https://api.github.com/repos/{github_repository.full_name}/rulesets"
     headers = {
         "Accept": "application/vnd.github+json",

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -212,7 +212,6 @@ def fixture_ruleset_protected_github_branch(
         "name": f"{github_branch.name}-ruleset",
         "target": "branch",
         "enforcement": "active",
-        "bypass_actors": [{"actor_id": 234, "actor_type": "Team", "bypass_mode": "always"}],
         "conditions": {
             "ref_name": {
                 "include": [f"refs/heads/{github_branch.name}"],

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -209,6 +209,9 @@ def fixture_ruleset_protected_github_branch(
     github_token: str, github_branch: Branch, github_repository: Repository
 ) -> Iterator[Branch]:
     """Add ruleset protection for a branch."""
+    # pygithub does not support the rulesets API yet:
+    # https://github.com/PyGithub/PyGithub/issues/2718
+    # We use the GitHub API with the requests module to create the ruleset
     url = f"https://api.github.com/repos/{github_repository.full_name}/rulesets"
     headers = {
         "Accept": "application/vnd.github+json",

--- a/tests/app/integration/test_target_branch_protection.py
+++ b/tests/app/integration/test_target_branch_protection.py
@@ -146,9 +146,7 @@ def test_fail_default_branch(
     assert repr(report) in caplog.text
 
 
-def test_fail_branch_missing(
-    forked_github_repository: Repository, caplog: pytest.LogCaptureFixture
-):
+def test_fail_branch_missing(github_repository_name: str, caplog: pytest.LogCaptureFixture):
     """
     arrange: given a branch that is missing.
     act: when target_branch_protection is called with the name of the branch.
@@ -157,9 +155,9 @@ def test_fail_branch_missing(
     branch_name = f"missing-branch-{uuid4()}"
     # The github_client is injected
     report = target_branch_protection(  # pylint: disable=no-value-for-parameter
-        repository_name=forked_github_repository.full_name,
+        repository_name=github_repository_name,
         branch_name=branch_name,
-        source_repository_name=forked_github_repository.full_name,
+        source_repository_name="other repository",
     )
 
     assert report.result == Result.FAIL
@@ -181,7 +179,7 @@ def test_fail_branch_missing(
 )
 @pytest.mark.usefixtures("protected_github_branch", "ruleset_protected_github_branch")
 def test_fail_branch_protection_using_rulesets(
-    github_branch: Branch, forked_github_repository: Repository, caplog: pytest.LogCaptureFixture
+    github_branch: Branch, github_repository_name: str, caplog: pytest.LogCaptureFixture
 ):
     """
     arrange: given a branch that is protected via ruleset and not the branch protection API.
@@ -190,9 +188,9 @@ def test_fail_branch_protection_using_rulesets(
     """
     # The github_client is injected
     report = target_branch_protection(  # pylint: disable=no-value-for-parameter
-        repository_name=forked_github_repository.full_name,
+        repository_name=github_repository_name,
         branch_name=github_branch.name,
-        source_repository_name=forked_github_repository.full_name,
+        source_repository_name="other repository",
     )
 
     assert report.result == Result.FAIL

--- a/tests/app/integration/test_target_branch_protection.py
+++ b/tests/app/integration/test_target_branch_protection.py
@@ -146,6 +146,62 @@ def test_fail_default_branch(
     assert repr(report) in caplog.text
 
 
+def test_fail_branch_missing(
+    forked_github_repository: Repository, caplog: pytest.LogCaptureFixture
+):
+    """
+    arrange: given a branch that is missing.
+    act: when target_branch_protection is called with the name of the branch.
+    assert: then a fail report is returned.
+    """
+    branch_name = f"missing-branch-{uuid4()}"
+    # The github_client is injected
+    report = target_branch_protection(  # pylint: disable=no-value-for-parameter
+        repository_name=forked_github_repository.full_name,
+        branch_name=branch_name,
+        source_repository_name=forked_github_repository.full_name,
+    )
+
+    assert report.result == Result.FAIL
+    assert report.reason, "expected a reason along with the fail result"
+    assert "not found" in report.reason
+    assert branch_name in report.reason
+    assert repr(report) in caplog.text
+
+
+@pytest.mark.parametrize(
+    "github_branch",
+    [
+        (
+            f"test-branch/target-branch/not-protected/{uuid4()}",
+            BranchWithProtection(branch_protection_enabled=False),
+        )
+    ],
+    indirect=["github_branch", "protected_github_branch"],
+)
+@pytest.mark.usefixtures("protected_github_branch", "ruleset_protected_github_branch")
+def test_fail_branch_protection_using_rulesets(
+    github_branch: Branch, forked_github_repository: Repository, caplog: pytest.LogCaptureFixture
+):
+    """
+    arrange: given a branch that is protected via ruleset and not the branch protection API.
+    act: when target_branch_protection is called with the name of the branch.
+    assert: then a fail report is returned.
+    """
+    # The github_client is injected
+    report = target_branch_protection(  # pylint: disable=no-value-for-parameter
+        repository_name=forked_github_repository.full_name,
+        branch_name=github_branch.name,
+        source_repository_name=forked_github_repository.full_name,
+    )
+
+    assert report.result == Result.FAIL
+    assert report.reason, "expected a reason along with the fail result"
+    assert "not enabled" in report.reason
+    assert github_branch.name in report.reason
+    assert repr(report) in caplog.text
+
+
 def test_pass_default_branch(
     github_repository_name: str, github_repository: Repository, caplog: pytest.LogCaptureFixture
 ):

--- a/tests/app/integration/test_target_branch_protection.py
+++ b/tests/app/integration/test_target_branch_protection.py
@@ -170,7 +170,7 @@ def test_fail_branch_missing(
 
 
 @pytest.mark.parametrize(
-    "github_branch",
+    "github_branch, protected_github_branch",
     [
         (
             f"test-branch/target-branch/not-protected/{uuid4()}",

--- a/tests/app/integration/test_target_branch_protection.py
+++ b/tests/app/integration/test_target_branch_protection.py
@@ -166,7 +166,6 @@ def test_fail_branch_missing(
     assert report.reason, "expected a reason along with the fail result"
     assert "A particular GitHub resource could not be found" in report.reason
     assert "Branch not found" in report.reason
-    assert branch_name in report.reason
     assert repr(report) in caplog.text
 
 

--- a/tests/app/integration/test_target_branch_protection.py
+++ b/tests/app/integration/test_target_branch_protection.py
@@ -164,7 +164,8 @@ def test_fail_branch_missing(
 
     assert report.result == Result.FAIL
     assert report.reason, "expected a reason along with the fail result"
-    assert "not found" in report.reason
+    assert "A particular GitHub resource could not be found" in report.reason
+    assert "Branch not found" in report.reason
     assert branch_name in report.reason
     assert repr(report) in caplog.text
 

--- a/tests/charm/integration/conftest.py
+++ b/tests/charm/integration/conftest.py
@@ -89,7 +89,6 @@ async def app_fixture(
             "plugin_hstore_enable": "true",
             "plugin_pg_trgm_enable": "true",
         },
-        revision=239
     )
     await model.integrate(app_name, f"{database_name}:database")
     await model.wait_for_idle(apps=[app_name, database_name], status="active")

--- a/tests/charm/integration/conftest.py
+++ b/tests/charm/integration/conftest.py
@@ -81,7 +81,7 @@ async def app_fixture(
     database_name = "postgresql-k8s"
     await model.deploy(
         database_name,
-        channel="14/stable",
+        channel="14/edge",
         series="jammy",
         trust=True,
         config={

--- a/tests/charm/integration/conftest.py
+++ b/tests/charm/integration/conftest.py
@@ -89,6 +89,7 @@ async def app_fixture(
             "plugin_hstore_enable": "true",
             "plugin_pg_trgm_enable": "true",
         },
+        revision=239
     )
     await model.integrate(app_name, f"{database_name}:database")
     await model.wait_for_idle(apps=[app_name, database_name], status="active")

--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ commands =
 passenv = GITHUB_TOKEN
 description = Run (charm) integration tests
 deps =
-    juju==3.1.*
+    juju==3.4.*
     pytest
     pytest-asyncio
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ deps =
     pylint
     pyproject-flake8<6.0.0
     pytest
+    types-requests
     toml
     types-PyYAML
 commands =
@@ -109,11 +110,13 @@ commands =
 [testenv:unit]
 description = Run application unit tests
 deps =
+    poetry
     pytest
     requests-mock
     coverage[toml]
     -r{[vars]tst_path}app/unit/requirements.txt
 commands =
+    poetry install
     coverage run --source={[vars]src_path} \
         -m pytest --ignore={[vars]app_tst_path}integration --ignore={[vars]charm_tst_path} -v --tb native -s {posargs}
 


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Catch 404 errors and do not return a 500 in this case.

Also handle the special case where a user specifies rulesets instead of branch protection, and return a special FAIL report for this.

### Rationale

Fix https://github.com/canonical/repo-policy-compliance/issues/788

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented on `pyproject.toml`

<!-- Explanation for any unchecked items above -->
