### PR TITLE
Add docs about token permissions

### DIFF
--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -50,8 +50,6 @@ config:
       default: false
     github_token:
       description: >-
-        The token to use for comms with GitHub. This can be a PAT or a fine-grained token
-        with permissions to read collaborators (and collaborators' permissions) and branches 
-        for all repositories that need to be checked.
-      type: string
-      required: true
+        The token to use for communication with GitHub. This can be a PAT (with repo scope)
+        or a fine-grained token with read permission for Administration and Pull requests 
+        (the latter is only required for private repos).

--- a/charm/docs/reference/token-permissions.md
+++ b/charm/docs/reference/token-permissions.md
@@ -1,0 +1,19 @@
+# GitHub Token Permissions
+
+You can either choose to use a personal access token (PAT) or a fine-grained access token for the 
+`github_token` configuration. The token permissions/scopes are different for each type of token.
+
+
+## Fine grained access token permissions
+
+**Note**: In addition to having a token with the necessary permissions, the user who owns the
+token also must have admin access to the organisation or repository.
+
+For fine-grained access control, the following repository scopes are required:
+
+- Administration: read
+- Pull requests: read (if you want to check private repositories)
+
+## Personal access token scopes
+
+If you want to use classic PATS, you will need to select the `repo` scope.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.9.1"
+version = "1.9.2"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,7 +3,7 @@
 
 name: repo-policy-compliance
 base: ubuntu@22.04
-version: '1.9.1'
+version: '1.9.2'
 summary: Check the repository setup for policy compliance
 description: |
     Used to check whether a GitHub repository complies with expected policies.


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Add documentation about token permissions. The documentation is not yet synchronised with charmhub.

### Rationale

The repo-policy-compliance charm can be used independently of the github runner charm, and has different token permissions/scope. This needs to be documented.

### Module Changes

n/a

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented on `pyproject.toml` and `rockcraft.yaml`

<!-- Explanation for any unchecked items above -->
