### PR TITLE
chore: Enable doc automation

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -23,4 +23,6 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
+      doc-automation-disabled: false
+      charm-directory: "charm"
     secrets: inherit


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Enable doc automation

### Rationale

to transfer the docs in `charm/docs` to charmhub when promoting the charm to stable.

### Module Changes

n/a

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented on `pyproject.toml` and `rockcraft.yaml`

<!-- Explanation for any unchecked items above -->
