### PR TITLE
chore: Add links to charmcraft.yaml

### DIFF
--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -18,6 +18,13 @@ summary: Check the repository setup for policy compliance
 description: |
   Used to check whether a GitHub repository complies with expected policies.
 
+links:
+  documentation: https://discourse.charmhub.io/t/repo-policy-compliance-documentation-overview/15558
+  issues: https://github.com/canonical/repo-policy-compliance/issues
+  source: https://github.com/canonical/repo-policy-compliance
+  website:
+    - https://github.com/canonical/repo-policy-compliance
+
 extensions:
   - flask-framework
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "repo-policy-compliance"
-version = "1.10.2"
+version = "1.10.3"
 description = "Checks GitHub repository settings for compliance with policy"
 authors = ["Canonical IS DevOps <launchpad.net/~canonical-is-devops>"]
 license = "Apache 2.0"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,7 +3,7 @@
 
 name: repo-policy-compliance
 base: ubuntu@22.04
-version: '1.10.2'
+version: '1.10.3'
 summary: Check the repository setup for policy compliance
 description: |
     Used to check whether a GitHub repository complies with expected policies.


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Add links to `charmcraft.yaml`

### Rationale

Required to display the documentation on https://charmhub.io/repo-policy-compliance

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Version has been incremented on `pyproject.toml` and `rockcraft.yaml`

<!-- Explanation for any unchecked items above -->
