### PR TITLE
chore: renovate group all non major

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,7 @@
 # pebble, false positive https://github.com/canonical/pebble/issues/498
 CVE-2024-34156
-# Vulnerability in golang.org/x/crypto introduced by statsd-exporter. We have to wait until it is fixed upstream: https://github.com/prometheus/statsd_exporter/blob/master/go.mod
+# Vulnerabilities in golang.org/x/crypto introduced by statsd-exporter. We have to wait until it is fixed upstream: https://github.com/prometheus/statsd_exporter/blob/master/go.mod
 CVE-2024-45337
+CVE-2025-22869
 # Vulnerability in golang.org/x/net introduced by statsd-exporter. We have to wait until it is fixed upstream: https://github.com/prometheus/statsd_exporter/blob/master/go.mod
 CVE-2024-45338

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "group:allNonMajor"
   ]
 }

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -9,6 +9,7 @@ import secrets
 from collections import namedtuple
 from enum import Enum
 from typing import Iterator, cast
+from uuid import uuid4
 
 import pytest
 import requests
@@ -191,7 +192,7 @@ def fixture_github_branch(
 ) -> Iterator[Branch]:
     """Create a new branch for testing."""
     branch_name: str = request.param
-    branch_name += secrets.token_hex(2) # add uniqueness to avoid conflict on deletion
+    branch_name += uuid4() # add uniqueness to avoid conflict on deletion
 
     main_branch = github_repository.get_branch(github_repository.default_branch)
     branch_ref = github_repository.create_git_ref(
@@ -210,7 +211,7 @@ def fixture_another_github_branch(
 ) -> Iterator[Branch]:
     """Create a new branch for testing."""
     branch_name: str = request.param
-    branch_name += secrets.token_hex(2)  # add uniqueness to avoid conflict on deletion
+    branch_name += uuid4()  # add uniqueness to avoid conflict on deletion
 
     main_branch = github_repository.get_branch(github_repository.default_branch)
     branch_ref = github_repository.create_git_ref(
@@ -229,7 +230,7 @@ def fixture_forked_github_branch(
 ) -> Iterator[Branch]:
     """Create a new forked branch for testing."""
     branch_name: str = request.param
-    branch_name += secrets.token_hex(2)  # add uniqueness to avoid conflict on deletion
+    branch_name += uuid4()  # add uniqueness to avoid conflict on deletion
 
     main_branch = forked_github_repository.get_branch(forked_github_repository.default_branch)
     branch_ref = forked_github_repository.create_git_ref(

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -192,7 +192,7 @@ def fixture_github_branch(
 ) -> Iterator[Branch]:
     """Create a new branch for testing."""
     branch_name: str = request.param
-    branch_name += uuid4() # add uniqueness to avoid conflict on deletion
+    branch_name += str(uuid4()) # add uniqueness to avoid conflict on deletion
 
     main_branch = github_repository.get_branch(github_repository.default_branch)
     branch_ref = github_repository.create_git_ref(
@@ -211,7 +211,7 @@ def fixture_another_github_branch(
 ) -> Iterator[Branch]:
     """Create a new branch for testing."""
     branch_name: str = request.param
-    branch_name += uuid4()  # add uniqueness to avoid conflict on deletion
+    branch_name += str(uuid4())  # add uniqueness to avoid conflict on deletion
 
     main_branch = github_repository.get_branch(github_repository.default_branch)
     branch_ref = github_repository.create_git_ref(
@@ -230,7 +230,7 @@ def fixture_forked_github_branch(
 ) -> Iterator[Branch]:
     """Create a new forked branch for testing."""
     branch_name: str = request.param
-    branch_name += uuid4()  # add uniqueness to avoid conflict on deletion
+    branch_name += str(uuid4())  # add uniqueness to avoid conflict on deletion
 
     main_branch = forked_github_repository.get_branch(forked_github_repository.default_branch)
     branch_ref = forked_github_repository.create_git_ref(

--- a/tests/app/integration/conftest.py
+++ b/tests/app/integration/conftest.py
@@ -5,6 +5,7 @@
 import enum
 import logging
 import os
+import secrets
 from collections import namedtuple
 from enum import Enum
 from typing import Iterator, cast
@@ -190,6 +191,7 @@ def fixture_github_branch(
 ) -> Iterator[Branch]:
     """Create a new branch for testing."""
     branch_name: str = request.param
+    branch_name += secrets.token_hex(2) # add uniqueness to avoid conflict on deletion
 
     main_branch = github_repository.get_branch(github_repository.default_branch)
     branch_ref = github_repository.create_git_ref(
@@ -208,6 +210,7 @@ def fixture_another_github_branch(
 ) -> Iterator[Branch]:
     """Create a new branch for testing."""
     branch_name: str = request.param
+    branch_name += secrets.token_hex(2)  # add uniqueness to avoid conflict on deletion
 
     main_branch = github_repository.get_branch(github_repository.default_branch)
     branch_ref = github_repository.create_git_ref(
@@ -226,6 +229,7 @@ def fixture_forked_github_branch(
 ) -> Iterator[Branch]:
     """Create a new forked branch for testing."""
     branch_name: str = request.param
+    branch_name += secrets.token_hex(2)  # add uniqueness to avoid conflict on deletion
 
     main_branch = forked_github_repository.get_branch(forked_github_repository.default_branch)
     branch_ref = forked_github_repository.create_git_ref(

--- a/tests/app/integration/test_blueprint.py
+++ b/tests/app/integration/test_blueprint.py
@@ -236,7 +236,7 @@ def test_check_run_missing_data(
     "github_branch, collaborators_with_permission",
     [
         (
-            f"test-branch/blueprint/pull-request/{uuid4()}",
+            f"test-branch/blueprint/pull-request/",
             RequestedCollaborator("admin", "admin"),
         )
     ],
@@ -290,25 +290,25 @@ def test_pull_request_check_run(
     "github_branch, collaborators_with_permission, endpoint",
     [
         pytest.param(
-            f"test-branch/blueprint/workflow-dispatch/fail/{uuid4()}",
+            f"test-branch/blueprint/workflow-dispatch/fail/",
             RequestedCollaborator("admin", "admin"),
             blueprint.WORKFLOW_DISPATCH_CHECK_RUN_ENDPOINT,
             id="workflow dispatch",
         ),
         pytest.param(
-            f"test-branch/blueprint/workflow-dispatch/fail/{uuid4()}",
+            f"test-branch/blueprint/workflow-dispatch/fail/",
             RequestedCollaborator("admin", "admin"),
             blueprint.PUSH_CHECK_RUN_ENDPOINT,
             id="push",
         ),
         pytest.param(
-            f"test-branch/blueprint/workflow-dispatch/fail/{uuid4()}",
+            f"test-branch/blueprint/workflow-dispatch/fail/",
             RequestedCollaborator("admin", "admin"),
             blueprint.SCHEDULE_CHECK_RUN_ENDPOINT,
             id="schedule",
         ),
         pytest.param(
-            f"test-branch/blueprint/workflow-dispatch/fail/{uuid4()}",
+            f"test-branch/blueprint/workflow-dispatch/fail/",
             RequestedCollaborator("admin", "admin"),
             blueprint.DEFAULT_CHECK_RUN_ENDPOINT,
             id="default",
@@ -527,7 +527,7 @@ def test_policy_invalid(client: FlaskClient, charm_token: str):
     "github_branch, collaborators_with_permission",
     [
         (
-            f"test-branch/blueprint/pull-request/fail-policy/{uuid4()}",
+            f"test-branch/blueprint/pull-request/fail-policy/",
             RequestedCollaborator("admin", "admin"),
         )
     ],
@@ -596,7 +596,7 @@ def test_pull_request_check_run_fail_policy_disabled(
     "github_branch, collaborators_with_permission",
     [
         (
-            f"test-branch/blueprint/workflow-dispatch/fail-policy/{uuid4()}",
+            f"test-branch/blueprint/workflow-dispatch/fail-policy/",
             RequestedCollaborator("admin", "admin"),
         )
     ],
@@ -661,7 +661,7 @@ def test_workflow_dispatch_check_run_fail_policy_disabled(
     "github_branch, collaborators_with_permission",
     [
         (
-            f"test-branch/blueprint/push/fail-policy/{uuid4()}",
+            f"test-branch/blueprint/push/fail-policy/",
             RequestedCollaborator("admin", "admin"),
         )
     ],
@@ -726,7 +726,7 @@ def test_push_check_run_policy_disabled(
     "github_branch, collaborators_with_permission",
     [
         (
-            f"test-branch/blueprint/schedule/fail-policy/{uuid4()}",
+            f"test-branch/blueprint/schedule/fail-policy/",
             RequestedCollaborator("admin", "admin"),
         )
     ],
@@ -914,7 +914,7 @@ def test_internal_server_error(
 
 @pytest.mark.parametrize(
     "forked_github_branch",
-    [f"test-branch/execute-job/no-comment-on-pr/{uuid4()}"],
+    [f"test-branch/execute-job/no-comment-on-pr/"],
     indirect=["forked_github_branch"],
 )
 @pytest.mark.usefixtures("pr_from_forked_github_branch", "make_fork_from_non_collaborator")

--- a/tests/app/integration/test_execute_job.py
+++ b/tests/app/integration/test_execute_job.py
@@ -45,7 +45,7 @@ def test_execute_job_not_fork():
 
 @pytest.mark.parametrize(
     "forked_github_branch",
-    [f"test-branch/execute-job/no-pr/{uuid4()}"],
+    [f"test-branch/execute-job/no-pr/"],
     indirect=True,
 )
 @pytest.mark.usefixtures("make_fork_from_non_collaborator")
@@ -74,7 +74,7 @@ def test_fail_forked_no_pr(
 
 @pytest.mark.parametrize(
     "forked_github_branch",
-    [f"test-branch/execute-job/no-comment-on-pr/{uuid4()}"],
+    [f"test-branch/execute-job/no-comment-on-pr/"],
     indirect=True,
 )
 @pytest.mark.usefixtures("pr_from_forked_github_branch", "make_fork_from_non_collaborator")
@@ -103,7 +103,7 @@ def test_fail_forked_no_comment_on_pr(
 
 @pytest.mark.parametrize(
     "forked_github_branch",
-    [f"test-branch/execute-job/wrong-comment-on-pr/{uuid4()}"],
+    [f"test-branch/execute-job/wrong-comment-on-pr/"],
     indirect=True,
 )
 @pytest.mark.usefixtures("make_fork_from_non_collaborator")
@@ -140,7 +140,7 @@ def test_fail_forked_wrong_comment_on_pr(
 
 @pytest.mark.parametrize(
     "forked_github_branch",
-    [f"test-branch/execute-job/wrong-commit-sha-on-pr/{uuid4()}"],
+    [f"test-branch/execute-job/wrong-commit-sha-on-pr/"],
     indirect=True,
 )
 @pytest.mark.usefixtures("make_fork_from_non_collaborator")
@@ -178,7 +178,7 @@ def test_fail_forked_wrong_commit_sha_on_pr(
 
 @pytest.mark.parametrize(
     "forked_github_branch",
-    [f"test-branch/execute-job/quoted-authorization/{uuid4()}"],
+    [f"test-branch/execute-job/quoted-authorization/"],
     indirect=True,
 )
 @pytest.mark.usefixtures("make_fork_from_non_collaborator")
@@ -215,7 +215,7 @@ def test_fail_forked_quoted_authorizationr(
 
 @pytest.mark.parametrize(
     "forked_github_branch",
-    [f"test-branch/execute-job/comment-from-wrong-user-on-pr/{uuid4()}"],
+    [f"test-branch/execute-job/comment-from-wrong-user-on-pr/"],
     indirect=True,
 )
 @pytest.mark.usefixtures("make_fork_from_non_collaborator")
@@ -269,7 +269,7 @@ def test_fail_forked_comment_from_wrong_user_on_pr(
 
 @pytest.mark.parametrize(
     "github_branch",
-    [f"test-branch/execute-job/repo-branch/{uuid4()}"],
+    [f"test-branch/execute-job/repo-branch/"],
     indirect=True,
 )
 def test_pass_main_repo(
@@ -303,7 +303,7 @@ def test_pass_main_repo(
 
 @pytest.mark.parametrize(
     "forked_github_branch",
-    [f"test-branch/execute-job/fork-branch/{uuid4()}"],
+    [f"test-branch/execute-job/fork-branch/"],
     indirect=True,
 )
 @pytest.mark.usefixtures("make_fork_from_non_collaborator")
@@ -353,7 +353,7 @@ def test_pass_fork(
 
 @pytest.mark.parametrize(
     "forked_github_branch",
-    [f"test-branch/execute-job/push-fork-branch/{uuid4()}"],
+    [f"test-branch/execute-job/push-fork-branch/"],
     indirect=True,
 )
 def test_pass_fork_collaborator_no_comment(

--- a/tests/app/integration/test_pull_request.py
+++ b/tests/app/integration/test_pull_request.py
@@ -41,14 +41,14 @@ def test_invalid_policy():
     "github_branch, protected_github_branch, policy_enabled, expected_result",
     [
         pytest.param(
-            f"test-branch/pull_request/pass/{uuid4()}",
+            f"test-branch/pull_request/pass/",
             BranchWithProtection(),
             True,
             Result.FAIL,
             id="disallow fork",
         ),
         pytest.param(
-            f"test-branch/pull_request/pass/{uuid4()}",
+            f"test-branch/pull_request/pass/",
             BranchWithProtection(),
             False,
             Result.PASS,
@@ -105,13 +105,13 @@ def test_pull_request_disallow_fork(  # pylint: disable=too-many-arguments
     "github_branch, policy_enabled, expected_result",
     [
         pytest.param(
-            f"test-branch/pull_request/target-branch-fail-enabled/{uuid4()}",
+            f"test-branch/pull_request/target-branch-fail-enabled/",
             True,
             Result.FAIL,
             id="policy enabled",
         ),
         pytest.param(
-            f"test-branch/pull_request/target-branch-fail-disabled/{uuid4()}",
+            f"test-branch/pull_request/target-branch-fail-disabled/",
             False,
             Result.PASS,
             id="policy disabled",
@@ -159,7 +159,7 @@ def test_target_branch(
     "expected_result",
     [
         pytest.param(
-            f"test-branch/pull_request/collaborators-fail-enabled/{uuid4()}",
+            f"test-branch/pull_request/collaborators-fail-enabled/",
             BranchWithProtection(),
             RequestedCollaborator("admin", "admin"),
             True,
@@ -167,7 +167,7 @@ def test_target_branch(
             id="policy enabled",
         ),
         pytest.param(
-            f"test-branch/pull_request/collaborators-fail-disabled/{uuid4()}",
+            f"test-branch/pull_request/collaborators-fail-disabled/",
             BranchWithProtection(),
             RequestedCollaborator("admin", "admin"),
             False,
@@ -215,17 +215,17 @@ def test_collaborators(
     "expected_result",
     [
         pytest.param(
-            f"test-branch/pull_request/execute-job-fail/target/{uuid4()}",
+            f"test-branch/pull_request/execute-job-fail/target/",
             BranchWithProtection(),
-            f"test-branch/pull_request/execute-job-fail/source/{uuid4()}",
+            f"test-branch/pull_request/execute-job-fail/source/",
             True,
             Result.FAIL,
             id="policy enabled",
         ),
         pytest.param(
-            f"test-branch/pull_request/execute-job-fail/target/{uuid4()}",
+            f"test-branch/pull_request/execute-job-fail/target/",
             BranchWithProtection(),
-            f"test-branch/pull_request/execute-job-fail/source/{uuid4()}",
+            f"test-branch/pull_request/execute-job-fail/source/",
             False,
             Result.PASS,
             id="policy disabled",
@@ -284,13 +284,13 @@ def test_execute_job(  # pylint: disable=too-many-arguments
     "github_branch, protected_github_branch, pull_request_kwargs",
     [
         pytest.param(
-            f"test-branch/pull_request/pass/{uuid4()}",
+            f"test-branch/pull_request/pass/",
             BranchWithProtection(),
             {},
             id="default policy",
         ),
         pytest.param(
-            f"test-branch/pull_request/pass/{uuid4()}",
+            f"test-branch/pull_request/pass/",
             BranchWithProtection(),
             {"policy_document": UsedPolicy.PULL_REQUEST_DISALLOW_FORK},
             id="all policy",

--- a/tests/app/integration/test_target_branch_protection.py
+++ b/tests/app/integration/test_target_branch_protection.py
@@ -21,13 +21,13 @@ from .types_ import BranchWithProtection
     "github_branch, protected_github_branch, reason_string_array",
     [
         pytest.param(
-            f"test-branch/target-branch/not-protected/{uuid4()}",
+            f"test-branch/target-branch/not-protected/",
             BranchWithProtection(branch_protection_enabled=False),
             ("not enabled"),
             id="branch_protection disabled",
         ),
         pytest.param(
-            f"test-branch/target-branch/pull-request-allowance-not-empty/{uuid4()}",
+            f"test-branch/target-branch/pull-request-allowance-not-empty/",
             BranchWithProtection(bypass_pull_request_allowance_disabled=False),
             ("pull request", "reviews", "can be bypassed"),
             id="pull-request-allowance not empty",
@@ -60,7 +60,7 @@ def test_fail(github_branch: Branch, reason_string_array: tuple[str], github_rep
     "github_branch",
     [
         pytest.param(
-            f"test-branch/target-branch/review-not-required/{uuid4()}",
+            f"test-branch/target-branch/review-not-required/",
             id="branch_protection disabled",
         )
     ],
@@ -93,7 +93,7 @@ def test_fail_pull_request_review_not_required(
 
 @pytest.mark.parametrize(
     "github_branch, protected_github_branch",
-    [(f"test-branch/target-branch/protected/{uuid4()}", BranchWithProtection())],
+    [(f"test-branch/target-branch/protected/", BranchWithProtection())],
     indirect=["github_branch", "protected_github_branch"],
 )
 @pytest.mark.usefixtures("protected_github_branch")
@@ -180,7 +180,7 @@ def test_fail_branch_missing(github_repository_name: str, caplog: pytest.LogCapt
     "github_branch, protected_github_branch",
     [
         (
-            f"test-branch/target-branch/not-protected/{uuid4()}",
+            f"test-branch/target-branch/not-protected/",
             BranchWithProtection(branch_protection_enabled=False),
         )
     ],
@@ -234,7 +234,7 @@ def test_pass_default_branch(
     "github_branch, protected_github_branch",
     [
         (
-            f"test-branch/target-branch/protected-on-repo/{uuid4()}",
+            f"test-branch/target-branch/protected-on-repo/",
             BranchWithProtection(
                 branch_protection_enabled=True, bypass_pull_request_allowance_disabled=False
             ),


### PR DESCRIPTION
Applicable spec: <link>

### Overview

group all non major renovate version updates

### Rationale

to reduce manual effort of merging/rebasing multiple PR's .  In general, non-major version updates should go smoothly without problems, unlike major updates, so we choose non-major.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] Version has been incremented on `pyproject.toml` and `rockcraft.yaml`

chore pr, not necessary to update versions

<!-- Explanation for any unchecked items above -->
