### PR TITLE
docs: apply suggestions from style guide check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Applicable spec: <link>
 
 <!-- The reason the change is needed -->
 
-### Module Changes
+### Module changes
 
 <!-- Any high level changes to modules and why (Service, Observer, helper) -->
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ bot to test things like comments from a user with no write permissions or above.
 
 GitHub actions should have access to the GitHub token via a secret
 called `PERSONAL_GITHUB_TOKEN`. It is recommended to use either a fine-grained PAT or a 
-token that is short-lived, e.g. 7 days. When it expires, a new token must be set.
+token that is short-lived, e.g. seven days. When it expires, a new token must be set.
 For the GitHub App Auth, the `TEST_GITHUB_APP_ID`, `TEST_GIHUB_APP_INSTALLATION_ID`, and
 `TEST_GITHUB_APP_PRIVATE_KEY` should be set as secrets.
 

--- a/charm/docs/index.md
+++ b/charm/docs/index.md
@@ -70,7 +70,7 @@ This section provides a brief overview on deploying, configuring and integrating
 * [A Kubernetes cloud](https://canonical-juju.readthedocs-hosted.com/en/3.6/user/reference/cloud/#machine-clouds-vs-kubernetes-clouds).
 * Juju 3 installed and a controller created. You can accomplish this process by using a Multipass VM as outlined in this guide: [Juju | Manage your deployment environment](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-your-deployment/manage-your-deployment-environment/#set-things-up).
 * A GitHub repository (formatted as `OWNER/REPO`) for which you want to check compliance.
-* A GitHub Personal Access Token with repo scope.
+* A GitHub Personal Access Token with repository scope.
 
 ### Set up 
 Create a Juju model:

--- a/charm/docs/reference/github-auth.md
+++ b/charm/docs/reference/github-auth.md
@@ -1,4 +1,4 @@
-# GitHub Authentication
+# GitHub authentication
 
 This section describes the GitHub authentication options available for the charm.
 

--- a/src-docs/check.py.md
+++ b/src-docs/check.py.md
@@ -5,7 +5,7 @@
 # <kbd>module</kbd> `check.py`
 Individual checks used to compose job checks. 
 
-**Global Variables**
+**Global variables**
 ---------------
 - **BYPASS_ALLOWANCES_KEY**
 - **FAILURE_MESSAGE**

--- a/src-docs/database.py.md
+++ b/src-docs/database.py.md
@@ -5,7 +5,7 @@
 # <kbd>module</kbd> `database.py`
 Provides persistence for runner tokens. 
 
-**Global Variables**
+**Global variables**
 ---------------
 - **db_connect_str**
 

--- a/src-docs/github_client.py.md
+++ b/src-docs/github_client.py.md
@@ -5,7 +5,7 @@
 # <kbd>module</kbd> `github_client.py`
 Module for GitHub client. 
 
-**Global Variables**
+**Global variables**
 ---------------
 - **GITHUB_TOKEN_ENV_NAME**
 - **GITHUB_APP_ID_ENV_NAME**
@@ -143,7 +143,7 @@ Get user permission for a given repository.
 **Args:**
  
  - <b>`repository`</b>:  The repository to get collaborators for. 
- - <b>`username`</b>:  The github login to check for permission. 
+ - <b>`username`</b>:  The Github login to check for permission.
 
 
 

--- a/src-docs/policy.py.md
+++ b/src-docs/policy.py.md
@@ -5,7 +5,7 @@
 # <kbd>module</kbd> `policy.py`
 Module for the policy document. 
 
-**Global Variables**
+**Global variables**
 ---------------
 - **ENABLED_KEY**
 - **ENABLED_RULE**


### PR DESCRIPTION
Applicable spec: None

### Overview

<!-- A high level overview of the change -->
Conduct local audit of this repository’s documentation against the Vale style checker in [GitHub - canonical/praecepta](https://github.com/canonical/praecepta) to align with [Ubuntu style guide](https://docs.ubuntu.com/styleguide/en).

### Rationale

<!-- The reason the change is needed -->
The errors are necessary to correct in order to make the Vale check mandatory without breaking the workflows.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
None

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] Version has been incremented on `pyproject.toml` and `rockcraft.yaml`

<!-- Explanation for any unchecked items above -->
No new documentation is generated. Version doesn't need to be incremented for documentation PR.